### PR TITLE
add erratum "Typographic error in description of tRNS"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3587,12 +3587,12 @@ greyscale and truecolour images). The <span class=
 </tr>
 
 <tr>
-<td class="Regular">Blue sample value</td>
-<td class="Regular">2 bytes</td>
+  <td class="Regular">Green sample value</td>
+  <td class="Regular">2 bytes</td>
 </tr>
 
 <tr>
-<td class="Regular">Green sample value</td>
+<td class="Regular">Blue sample value</td>
 <td class="Regular">2 bytes</td>
 </tr>
 


### PR DESCRIPTION
Add erratum ["Typographic error in description of tRNS"](https://www.w3.org/2003/11/REC-PNG-20031110-errata).

The 2003 Recommendation [inadvertently had RBG rather than RGB](https://www.w3.org/TR/2003/REC-PNG-20031110/#11tRNS) order for Color type 2.