### PR TITLE
Update mailing list

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@ needs update, comment out for now
 <p>The PNG specification enjoys a good level of <a href="http://www.libpng.org/pub/png/pngstatus.html">implementation</a>  with good interoperability. At the time of this publication more than 180 <a href="http://www.libpng.org/pub/png/pngapvw.html">image viewers</a> could display PNG images and over 100 <a href="http://www.libpng.org/pub/png/pngaped.html">image editors</a> could read and write valid PNG files. Full support of PNG is  required  for conforming <a href="/Graphics/SVG">SVG</a> viewers; at the time of publication all eighteen <a href="/Graphics/SVG/SVG-Implementations.htm8#viewer">SVG viewers</a> had PNG support. HTML has no required image formats, but over 60 <a href="http://www.libpng.org/pub/png/pngapbr.html">HTML browsers</a> had at least basic support of PNG images.</p> -->
 
     <p>Public comments on this W3C Recommendation are welcome.
-    Please send them to the <a href="http://lists.w3.org/Archives/Public/png-group">archived</a> list <a href="mailto:png-group@w3.org">png-group@w3.org</a>.</p>
+    Please send them to the <a href="https://lists.w3.org/Archives/Public/public-png/">archived</a> list <a href="mailto:public-png@w3.org">public-png@w3.org</a>.</p>
 
     <p>The latest information regarding <a rel="disclosure"
     href="http://www.w3.org/Graphics/PNG/Disclosures">patent
@@ -2120,7 +2120,7 @@ have designated the following as the registration authority:</p>
 
 <address>FRANCE</address>
 
-<address>Email:png-group@w3.org</address>
+<address>Email:public-png@w3.org</address>
 
 <p>To ensure timely processing the Registration Authority should be contacted by email.</p>
 
@@ -7886,7 +7886,7 @@ accessed from the PNG web site.</p>
 <h2><a name="E-Email">Electronic mail</a></h2>
 
 <p>Queries concerning PNG developments may be addressed to <a href=
-"mailto:png-group@w3.org"><tt>png-group@w3.org</tt></a>.
+"mailto:public-png@w3.org"><tt>public-png@w3.org</tt></a>.
 <!-- ************Page Break******************* -->
 </p>
 


### PR DESCRIPTION
Currently, the PNG spec has png-group@w3.org as the mailing list.
This list is no longer the list primarily being used.

This commit changes the mailing list to public-png@w3.org, which is
the currently used mailing list.