### PR TITLE
Use HTTPS for ReSpec fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     /* remove annoying green color from definition terms */
     dt {color: black}
     </style>
-    <script src="http://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <script class="remove">
       var respecConfig = {
           specStatus: "ED",


### PR DESCRIPTION
Currently, ReSpec is fetched via HTTP.
If the spec is hosted via HTTPS, the HTTP ReSpec request will be denied
in modern browser settings. This results in ReSpec styling not being
applied.

This commit fetches ReSpec via HTTPS.