### PR TITLE
Use International English spellings

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <!-- <link rel="stylesheet" href="./isostyle.css" type="text/css" /> -->
     <style type="text/css">
-    /* remove annoying green color from definition terms */
+    /* remove annoying green colour from definition terms */
     dt {color: black}
     </style>
     <script src="http://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
@@ -71,8 +71,8 @@
   </head>
   <body>
     <section id="abstract">
-      <p>This document describes PNG (Portable Network Graphics), an extensible file format for the lossless, portable, well-compressed storage of raster images. PNG provides a patent-free replacement for GIF and can also replace many common uses of TIFF. Indexed-color, greyscale, and truecolor images are supported, plus an optional alpha channel. Sample depths range from 1 to 16 bits.</p>
-      <p>PNG is designed to work well in online viewing applications, such as the World Wide Web, so it is fully streamable with a progressive display option. PNG is robust, providing both full file integrity checking and simple detection of common transmission errors. Also, PNG can store gamma and chromaticity data for improved color matching on heterogeneous platforms.</p>
+      <p>This document describes PNG (Portable Network Graphics), an extensible file format for the lossless, portable, well-compressed storage of raster images. PNG provides a patent-free replacement for GIF and can also replace many common uses of TIFF. Indexed-colour, greyscale, and truecolour images are supported, plus an optional alpha channel. Sample depths range from 1 to 16 bits.</p>
+      <p>PNG is designed to work well in online viewing applications, such as the World Wide Web, so it is fully streamable with a progressive display option. PNG is robust, providing both full file integrity checking and simple detection of common transmission errors. Also, PNG can store gamma and chromaticity data for improved colour matching on heterogeneous platforms.</p>
       <p>This specification defines an Internet Media Type image/png.</p>
 
 <!--
@@ -2023,7 +2023,7 @@ third letters.</td>
 is needed by PNG editors. This bit defines the proper handling of
 unrecognized chunks in a datastream that is being modified. Rules
 for PNG editors are discussed further in 14.2: <a href=
-"#behavior-of-png-editors"><span class="xref">Behaviour of PNG
+"#behaviour-of-png-editors"><span class="xref">Behaviour of PNG
 editors</span></a>.</td>
 </tr>
 </table>


### PR DESCRIPTION
There are a few more US English spellings still in the spec.

This commit changes them to International English spellings.

Closes #4