### PR TITLE
Fix broken table fragments

### DIFF
--- a/index.html
+++ b/index.html
@@ -1590,10 +1590,11 @@ Decoders may ignore all or some of the ancillary information. The
 types of ancillary information provided are described in <a href=
 "#table41"><span class="tabref">Table 4.1</span></a>.</p>
 
-<table class="Regular" summary=
+<!-- Maintain a fragment named "table41" to preserve incoming links to it -->
+<table id="table41" class="Regular" summary=
 "This table lists the types of ancillary information that may be associated with an image">
-<caption><a name="table41"><b>Table 4.1 &mdash; Types of
-ancillary information</b></a></caption>
+<caption><b>Table 4.1 &mdash; Types of
+ancillary information</b></caption>
 
 <tr>
 <th>Type of information</th>
@@ -1847,10 +1848,10 @@ The chunk data field may be empty.</p>
 <figcaption>Chunk parts</figcaption>
 </figure>
 
-
-<table class="Regular" summary=
+<!-- Maintain a fragment named "table51" to preserve incoming links to it -->
+<table id="table51" class="Regular" summary=
 "This table defines the chunk fields">
-<caption><a name="table51"><b>Table 5.1 &mdash; Chunk fields</b></a></caption>
+<caption><b>Table 5.1 &mdash; Chunk fields</b></caption>
 <tr>
 <td class="Regular">Length</td>
 <td class="Regular">A four-byte unsigned integer giving the number of bytes in
@@ -1935,9 +1936,10 @@ defined in
 <a href="#table52"><span class="tabref">Table 5.2</span></a>.
 </p>
 
-<table class="Regular" summary=
+<!-- Maintain a fragment named "table52" to preserve incoming links to it -->
+<table id="table52" class="Regular" summary=
 "This table defines the semantics of the property bits">
-<caption><a name="table52"><b>Table 5.2 &mdash; Semantics of property bits</b></a></caption>
+<caption><b>Table 5.2 &mdash; Semantics of property bits</b></caption>
 <tr>
 <td class="Regular">Ancillary bit: first byte</td>
 <td class="Regular">0 (uppercase) = critical,<br class="xhtml" />
@@ -2064,10 +2066,11 @@ two chunk types indicates alternatives.</p>
 
 <!-- ************Page Break******************* -->
 <!-- ************Page Break******************* -->
-<table class="Regular" summary=
+<!-- Maintain a fragment named "table53" to preserve incoming links to it -->
+<table id="table53" class="Regular" summary=
 "This table lists the chunk ordering rules">
-<caption><a name="table53"><b>Table 5.3 &mdash; Chunk ordering
-rules</b></a></caption>
+<caption><b>Table 5.3 &mdash; Chunk ordering
+rules</b></caption>
 
 <tr>
 <th colspan="3">Critical chunks<br class="xhtml" />
@@ -2222,10 +2225,11 @@ before <a href="#idat-image-data"><span class="chunk">IDAT</span></a>
 </tr>
 </table>
 
-<table class="Regular"  summary=
+<!-- Maintain a fragment named "table54" to preserve incoming links to it -->
+<table id="table54" class="Regular"  summary=
 "This table lists the symbols used in lattice diagrams">
-<caption><a name="table54"><b>Table 5.4 &mdash; Meaning of
-symbols used in lattice diagrams</b></a></caption>
+<caption><b>Table 5.4 &mdash; Meaning of
+symbols used in lattice diagrams</b></caption>
 
 <tr>
 <th>Symbol</th>
@@ -2390,10 +2394,11 @@ have an explicit alpha channel. The PNG image types and
 corresponding colour types are listed in <a href=
 "#table6.1"><span class="tabref">Table 6.1</span></a>.</p>
 
-<table class="Regular"  summary=
+<!-- Maintain a fragment named "table6.1" to preserve incoming links to it -->
+<table id="table6.1" class="Regular"  summary=
 "This table lists the PNG image and colour types">
-<caption><a name="table6.1"><b>Table 6.1 &mdash; PNG image types
-and colour types</b></a></caption>
+<caption><b>Table 6.1 &mdash; PNG image types
+and colour types</b></caption>
 
 <tr>
 <th>PNG image type</th>
@@ -2787,10 +2792,11 @@ it is sufficient to check the filter method in <a href="#ihdr-image-header"><spa
 
 <!-- ************Page Break******************* -->
 <!-- ************Page Break******************* -->
-<table class="Regular" summary=
+<!-- Maintain a fragment named "9-table91" to preserve incoming links to it -->
+<table id="9-table91" class="Regular" summary=
 "This table lists the filter types">
-<caption><a name="9-table91"><b>Table 9.1 &mdash; Filter
-types</b></a></caption>
+<caption><b>Table 9.1 &mdash; Filter
+types</b></caption>
 
 <tr>
 <th>Type</th>
@@ -3162,10 +3168,11 @@ simplify implementations and to prohibit combinations that do not
 compress well. The allowed combinations are defined in <a href=
 "#table111"><span class="tabref">Table 11.1</span></a>.</p>
 
-<table class="Regular" summary=
+<!-- Maintain a fragment named "table111" to preserve incoming links to it -->
+<table id="table111" class="Regular" summary=
 "This table defines the colour types">
-<caption><a name="table111"><b>Table 11.1 &mdash; Allowed
-combinations of colour type and bit depth</b></a></caption>
+<caption><b>Table 11.1 &mdash; Allowed
+combinations of colour type and bit depth</b></caption>
 
 <tr>
 <th>PNG image type</th>
@@ -5292,10 +5299,11 @@ which are given in <a href="#12-table121"><span class=
 
 <!-- ************Page Break******************* -->
 <!-- ************Page Break******************* -->
-<table class="Regular" summary=
+<!-- Maintain a fragment named "12-table121" to preserve incoming links to it -->
+<table id="12-table121" class="Regular" summary=
 "CCIR 709 primaries and D65 whitepoint">
-<caption><a name="12-table121"><b>Table 12.1 &mdash; CCIR 709
-primaries and D65 whitepoint</b></a></caption>
+<caption><b>Table 12.1 &mdash; CCIR 709
+primaries and D65 whitepoint</b></caption>
 
 <tr>
 <th>&nbsp;</th>
@@ -5326,10 +5334,11 @@ primaries and D65 whitepoint</b></a></caption>
 given in <a href="#12-table122"><span class="tabref">Table
 12.2</span></a>.</p>
 
-<table class="Regular" summary=
+<!-- Maintain a fragment named "12-table122" to preserve incoming links to it -->
+<table id="12-table122" class="Regular" summary=
 "CSMPTE-C video standard">
-<caption><a name="12-table122"><b>Table 12.2 &mdash; SMPTE-C
-video standard</b></a></caption>
+<caption><b>Table 12.2 &mdash; SMPTE-C
+video standard</b></caption>
 
 <tr>
 <th>&nbsp;</th>
@@ -7702,10 +7711,11 @@ hints in <a href="#D-tabled1"><span class="tabref">Table
 D.1</span></a> may help non-C users to read the code more
 easily.</p>
 
-<table class="Regular" summary=
+<!-- Maintain a fragment named "D-tabled1" to preserve incoming links to it -->
+<table id="D-tabled1" class="Regular" summary=
 "This table gives hints for reading the CRC code">
-<caption><a name="D-tabled1"><b>Table D.1 &mdash; Hints for
-reading ISO C code</b></a></caption>
+<caption><b>Table D.1 &mdash; Hints for
+reading ISO C code</b></caption>
 
 <tr>
 <td class="Regular"><tt>&amp;</tt> </td>


### PR DESCRIPTION
Tables were using the old fragment style <a name="frag_name"></a>.
ReSpec correctly errored on these.

ReSpec has a special way to handle figures. But it doesn't yet have a
special way to handle tables. There is discussion about this here:
https://github.com/w3c/respec/issues/4004

This commit will leave the tables in place for now (not using any
special ReSpec handling) but corrects the fragments. It also adds a
comment to preserve fragments. This fixes several ReSpec errors.

Closes #99