### PR TITLE
Add group to ReSpec config

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <script class="remove">
       var respecConfig = {
+          group: "png",
           specStatus: "ED",
 	  shortName: "PNG",
 	  copyrightStart: "1996",


### PR DESCRIPTION
ReSpec is giving an error that the config is missing a group.

This commit adds the correct group to the ReSpec config.

Closes #101