### PR TITLE
Fix ReSpec config

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 	      { name: "Chris Lilley", url: "https://svgees.us", company: "W3C", companyURL: "https://www.w3.org" },
 	      { name: "Dave Martindale" },
 	      { name: "Owen Mortensen" },
-        { name: "Stuart Parmenter"},
+              { name: "Stuart Parmenter"},
 	      { name: "Keith S. Pickens" },
 	      { name: "Robert P. Poole", url: "http://www.users.qwest.net/~lionlad/" },
 	      { name: "Glenn Randers-Pehrson" },
@@ -60,9 +60,9 @@
 	      { name: "Willem van Schaik", url: "http://www.schaik.com/" },
 	      { name: "Guy Schalnat" },
 	      { name: "Paul Schmidt" },
-        { name: "Andrew Smith" }
+              { name: "Andrew Smith" },
 	      { name: "Michael Stokes" },
-        { name: "Vladimir Vukicevic" },
+              { name: "Vladimir Vukicevic" },
 	      { name: "Tim Wegner" },
 	      { name: "Jeremy Wohl" }
 	  ],


### PR DESCRIPTION
There was a missing comma in the ReSpec config which was causing a JS
error. Additionally, the indentation of a few elements was off.

This commit fixes those things.