### PR TITLE
Remove "Relationship to W3C PNG", add up to date changes section

### DIFF
--- a/index.html
+++ b/index.html
@@ -7976,10 +7976,10 @@ specified in this specification.</li>
 <li>No chunks appear in the PNG datastream other than those
 specified in this specification or those defined
 according to the rules for creating new chunk types as defined in
-this specification.</li>
+this International Standard.</li>
 
 <li>The PNG datastream is encoded according to the rules of this
-specification.</li>
+International Standard.</li>
 </ol>
 </section>
 
@@ -7990,7 +7990,7 @@ specification.</li>
 <h2>Conformance of PNG
 encoders</h2>
 
-<p>A PNG encoder conforms to this specification if it
+<p>A PNG encoder conforms to this International Standard if it
 satisfies the following conditions.</p>
 
 <!-- <ol start="1"> --><ol>
@@ -8014,12 +8014,12 @@ fields.</li>
 <h2>Conformance of PNG
 decoders</h2>
 
-<p>A PNG decoder conforms to this specification if it
+<p>A PNG decoder conforms to this International Standard if it
 satisfies the following conditions.</p>
 
 <!-- <ol start="1"> --><ol>
 <li>It is able to read any PNG datastream that conforms to this
-specification, including both public and private chunks
+International Standard, including both public and private chunks
 whose types may not be recognized.</li>
 
 <li>It supports all the standardized critical chunks, and all the
@@ -8081,7 +8081,7 @@ ordering rules.</li>
 <h2>Conformance of PNG
 editors</h2>
 
-<p>A PNG editor conforms to this specification if it satisfies the following conditions.</p>
+<p>A PNG editor conforms to this International Standard if it satisfies the following conditions.</p>
 
 <ol>
 <li>It conforms to the requirements for PNG encoders.</li>

--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@ main design goal.</p>
 
 <p>The following normative documents contain provisions which,
 through reference in this text, constitute provisions of this
-International Standard. For dated references, subsequent
+specification. For dated references, subsequent
 amendments to, or revisions of, any of these publications do not
 apply. However, parties to agreements based on this International
 Standard are encouraged to investigate the possibility of
@@ -1207,8 +1207,8 @@ transforms the source image into a reference image, then
 transforms the reference image into a PNG image. Depending on the
 type of source image, the transformation from the source image to
 a reference image may require the loss of information. That
-transformation is beyond the scope of this International
-Standard. The reference image, however, can always be recovered
+transformation is beyond the scope of this specification.
+The reference image, however, can always be recovered
 exactly from a PNG datastream.</li>
 
 <li>The <i>PNG image</i> is obtained from the reference image by
@@ -2261,7 +2261,7 @@ letters.
 this version of PNG.</td>
 <td class="Regular">The significance of the case of the third letter of the chunk
 name is reserved for possible future extension. In this
-International Standard, all chunk names shall have uppercase
+specification, all chunk names shall have uppercase
 third letters.</td>
 </tr>
 
@@ -6467,7 +6467,7 @@ recommendations.</p>
 <p>PNG decoders shall support all valid combinations of bit
 depth, colour type, compression method, filter method, and
 interlace method that are explicitly defined in this
-International Standard.</p>
+specification.</p>
 
 </section>
 
@@ -7974,7 +7974,7 @@ according to the rules for creating new chunk types as defined in
 this specification.</li>
 
 <li>The PNG datastream is encoded according to the rules of this
-International Standard.</li>
+specification.</li>
 </ol>
 </section>
 
@@ -8014,7 +8014,7 @@ satisfies the following conditions.</p>
 
 <!-- <ol start="1"> --><ol>
 <li>It is able to read any PNG datastream that conforms to this
-International Standard, including both public and private chunks
+specification, including both public and private chunks
 whose types may not be recognized.</li>
 
 <li>It supports all the standardized critical chunks, and all the

--- a/index.html
+++ b/index.html
@@ -161,7 +161,15 @@ needs update, comment out for now
 
 <p>The PNG specification enjoys a good level of <a href="http://www.libpng.org/pub/png/pngstatus.html">implementation</a>  with good interoperability. At the time of this publication more than 180 <a href="http://www.libpng.org/pub/png/pngapvw.html">image viewers</a> could display PNG images and over 100 <a href="http://www.libpng.org/pub/png/pngaped.html">image editors</a> could read and write valid PNG files. Full support of PNG is  required  for conforming <a href="/Graphics/SVG">SVG</a> viewers; at the time of publication all eighteen <a href="/Graphics/SVG/SVG-Implementations.htm8#viewer">SVG viewers</a> had PNG support. HTML has no required image formats, but over 60 <a href="http://www.libpng.org/pub/png/pngapbr.html">HTML browsers</a> had at least basic support of PNG images.</p> -->
     </section>
-    <section id="sotd"></section>
+    <section id="sotd">
+      <p>
+        This specification is intended to become
+        an International Standard,
+        but is not yet one.
+        It is inappropriate to refer to this specification
+        as an International Standard.
+      </p>
+    </section>
 
 <!-- *********************************************************************
 

--- a/index.html
+++ b/index.html
@@ -8695,209 +8695,56 @@ accessed from the PNG web site.</p>
 </section>
 </section>
 
-<!-- Maintain a fragment named "F-Relationship" to preserve incoming links to it -->
-<section class="appendix informative" id="F-Relationship">
-<!-- Maintain a fragment named "relationshiptofirstedition" to preserve incoming links to it -->
-<h2 class="Annex" id="relationshiptofirstedition">Relationship to W3C PNG</h2>
-
-<p>This specification is strongly based on W3C
-Recommendation PNG Specification Version 1.0 <a href=
-"#PNG-1.0">[PNG-1.0]</a> which was reviewed by W3C members,
-approved as a W3C Recommendation, and published in October 1996
-according to the established W3C process. Subsequent amendments
-to the PNG Specification have also been incorporated into this
-International Standard <a href="#PNG-1.0">[PNG-1.1]</a>, <a
-href="#PNG-1.0">[PNG-1.2]</a>.</p>
-
-<p>A complete review of the document has been done by ISO/IEC/JTC
-1/SC 24 in collaboration with W3C in order to transform this
-recommendation into an ISO/IEC international standard. A major
-design goal during this review was to avoid changes that will
-invalidate existing files, editors, or viewers that conform to
-W3C Recommendation PNG Specification Version 1.0.</p>
-
-<p>The W3C PNG Recommendation was developed with major
-contribution from the following people.</p>
-<!-- Maintain a fragment named "F-Editor10" to preserve incoming links to it -->
-<h2 id="F-Editor10">Editor (Version 1.0)</h2>
-
-<p>Thomas Boutell, <span class="email">boutell @ boutell.com</span></p>
-
-<!-- Maintain a fragment named "F-Editor12" to preserve incoming links to it -->
-<h2 id="F-Editor12">Editor (Versions 1.1 and 1.2)</h2>
-
-<p>Glenn Randers-Pehrson, <span class="email">randeg @ alum.rpi.edu</span></p>
-
-<!-- Maintain a fragment named "F-ContribEditor10" to preserve incoming links to it -->
-<h2 id="F-ContribEditor10">
-Contributing Editor (Version
-1.0)</h2>
-
-<p>Tom Lane, <span class="email">tgl @ sss.pgh.pa.us</span></p>
-
-<!-- Maintain a fragment named "F-ContribEditor12" to preserve incoming links to it -->
-<h2 id="F-ContribEditor12">
-Contributing Editor (Versions 1.1
-and 1.2)</h2>
-
-<p>Adam M. Costello, <span class="email">png-spec.amc @ nicemice.net</span></p>
-
-<!-- Maintain a fragment named "F-Authors" to preserve incoming links to it -->
-<h2 id="F-Authors">
-Authors (Versions 1.0, 1.1, and 1.2
-combined)</h2>
-
-<p><strong>Authors' names are presented in alphabetical
-order.</strong></p>
-
-<ul>
-<li><a href="http://www.alumni.caltech.edu/~madler/">Mark Adler</a>,
-<span class="email">madler @ alumni.caltech.edu</span></li>
-
-<li><a href="http://www.boutell.com/boutell/">Thomas Boutell</a>,
-<span class="email">boutell @ boutell.com</span></li>
-
-<li>John Bowler, <span class="mail">jbowler @ acm.org</span></li>
-
-<li><a href="http://www.df.lth.se/~cb/">Christian Brunschen</a>,
-<span class="email">cb @ brunschen.com</span></li>
-
-<li><a href="http://www.nicemice.net/amc/">Adam M.
-Costello</a>, <span class=
-"email">png-spec.amc @ nicemice.net</span></li>
-
-<li><a href="http://www.piclab.com/">Lee Daniel Crocker</a>,
-<span class="email">lee @ piclab.com</span></li>
-
-<li><a href=
-"http://www-mddsp.enel.ucalgary.ca/People/adilger/">Andreas
-Dilger</a>, <span class=
-"email">adilger @ turbolabs.com</span></li>
-
-<li><a href="http://www.fromme.com/">Oliver Fromme</a>, <span
-class="email">oliver @ fromme.com</span></li>
-
-<li><a href="http://www.teaser.fr/~jlgailly/">Jean-loup
-Gailly</a>, <span class="email">jloup @ gzip.org</span></li>
-
-<li>Chris Herborth, <span class=
-"email">chrish @ pobox.com</span></li>
-
-<li>Alex Jakulin, <span class=
-"email">jakulin @ acm.org</span></li>
-
-<li>Neal Kettler, <span class=
-"email">neal @ westwood.com</span></li>
-
-<li>Tom Lane, <span class="email">tgl @ sss.pgh.pa.us</span></li>
-
-<li>Alexander Lehmann, <span class=
-"email">lehmann @ usa.net</span></li>
-
-
-<!-- ************Page Break******************* -->
-<!-- ************Page Break******************* -->
-
-<li><a href="http://www.w3.org/People/chris/">Chris Lilley</a>,
-<span class="email">chris @ w3.org</span></li>
-
-<li>Dave Martindale, <span class=
-"email">davem @ cs.ubc.ca</span></li>
-
-<li>Owen Mortensen, <span class="email">ojm @ acm.org</span></li>
-
-<li>Keith S. Pickens, <span class=
-"email">ksp @ rice.edu</span></li>
-
-<li><a href="http://www.users.qwest.net/~lionlad/">Robert P. Poole</a>, <span class=
-"email">lionlad @ qwest.net</span></li>
-
-<li>Glenn Randers-Pehrson, <span class=
-"email">randeg @ alum.rpi.edu</span></li>
-
-<li><a href="http://pobox.com/~newt/">Greg Roelofs</a>, <span
-class="email">newt @ pobox.com</span></li>
-
-<li><a href="http://www.schaik.com/">Willem van Schaik</a>, <span
-class="email">willem @ schaik.com</span></li>
-
-<li>Guy Schalnat, <span class=
-"email">gschal @ infinet.com</span></li>
-
-<li>Paul Schmidt, <span class=
-"email">pschmidt @ photodex.com</span></li>
-
-<li>Michael Stokes, <span class=
-"email">mistokes @ microsoft.com</span></li>
-
-<li>Tim Wegner, <span class=
-"email">twegner @ phoenix.net</span></li>
-
-<li>Jeremy Wohl, <span class=
-"email">jeremyw @ evantide.com</span></li>
-</ul>
+<section class="appendix informative">
 
 <!-- Maintain a fragment named "F-ChangeList" to preserve incoming links to it -->
-<h2 id="F-ChangeList">
-List of changes between W3C
-Recommendation PNG Specification Version 1.0 and this
-International Standard</h2>
+<a id="F-ChangeList"></a>
 
-<!-- Maintain a fragment named "F-EditorialChanges" to preserve incoming links to it -->
-<h2 id="F-EditorialChanges">
-Editorial changes</h2>
+<h2 class="Annex">Changes</h2>
 
-<p>The document has been reformatted according to the
-requirements of ISO.</p>
+<h3>Changes since the
+  <a href="https://www.w3.org/TR/2003/REC-PNG-20031110/">W3C Recommendation
+    of 10 November 2003</a> (PNG Second Edition)
+</h3>
 
-<!-- <ol start="1"> --><ol>
-<li>A concepts clause has been introduced.</li>
+<ul>
+  <!-- to 5 Apr 2022 -->
+  <li>The three previously defined, but unofficial, chunks
+    for [=APNG=] have been added.
+    This brings the PNG specification into alignment
+    with widely deployed industry practice.
+  </li>
+  <li>Added the <span class="chunk">cICP</span> chunk,
+    Coding-independent code points for video signal type identification,
+    to contain image color space metadata
+    defined in [[ITU-T H.273]]
+    which enables PNG to contain High Dynamic Range (HDR) images.
+  </li>
+  <li>The previously defined <span class="chunk">eXIf</span> chunk
+    has been moved from the PNG-Extensions document [[PNG-EXTENSIONS]]
+    into the main body of this specification,
+    to reflect it's widespready use.
+  </li>
+  <li>Incorporation of all
+    <a href="https://www.w3.org/2003/11/REC-PNG-20031110-errata">PNG Second Edition Errata</a>
+  </li>
+  <li>Various editorial clarifications in response to community feedback</li>
+  <li>References updated to latest versions</li>
+  <li>Markup corrections and link fixes</li>
+  <li>Document source reformatted to use ReSpec</li>
+</ul>
 
-<li>Conformance for datastreams, encoders, decoders, and editors
-has been defined in a conformance clause.</li>
-</ol>
+<h3>Changes between First and Second Editions
+</h3>
 
-<!-- Maintain a fragment named "F-TechnicalChanges" to preserve incoming links to it -->
-<h2 id="F-TechnicalChanges">
-Technical changes</h2>
+<p>For the list of changes between W3C
+Recommendation <a href="https://www.w3.org/TR/REC-png-961001">PNG Specification Version 1.0</a> and
+<a href="https://www.w3.org/TR/2003/REC-PNG-20031110/">PNG Second Edition</a>,
+see
+  <a href="https://www.w3.org/TR/2003/REC-PNG-20031110/#F-ChangeList">PNG
+    Second Edition changelist</a>
+</p>
 
-<!-- <ol start="1"> --><ol>
-<li>New chunk types introduced in PNG version 1.1 and 1.2 have
-been incorporated (<a href="#iccp-embedded-icc-profile"><span class=
-"chunk">iCCP</span></a>, <a href="#itxt-international-textual-data"><span class=
-"chunk">iTXt</span></a>, <a href="#srgb-standard-colour-space"><span class=
-"chunk">sRGB</span></a>, <a href="#splt-suggested-palette"><span class=
-"chunk">sPLT</span></a>).
-In the
-<a href="#itxt-international-5extual-data"><span class=
-"chunk">iTXt</span></a>
-chunk, the language tag has been updated from RFC 1766 to RFC 3066.</li>
-
-<li>In accord with version 1.1, the scope of the 31-bit limit on
-chunk lengths and image dimensions has been extended to apply to
-all four-byte unsigned integers. The value -2<sup>31</sup> is not
-allowed in signed integers.</li>
-
-<li>The redefinition of <a href="#gama-image-gamma"><span class=
-"chunk">gAMA</span></a> to be in terms of the desired display
-output rather than the original scene, introduced in PNG version
-1.1, has been incorporated.</li>
-
-<li>The use of the <a href="#plte-palette"><span class=
-"chunk">PLTE</span></a> and <a href="#hist-image-histogram"><span class=
-"chunk">hIST</span></a> chunks in non-indexed-colour images has
-been discouraged in favour of the <a href="#splt-suggested-palette"><span class=
-"chunk">sPLT</span></a> chunk.</li>
-
-<li>Some recommendations for PNG encoders, decoders, and editors
-have been strengthened to requirements. These changes do not
-affect the conformance of PNG datastreams, and do not compromise
-interoperability.</li>
-
-<li>The sample depth of channels not mentioned in the <a href=
-"#sbit-significant-bits"><span class="chunk">sBIT</span></a> chunk has been
-clarified.</li>
-</ol>
 </section>
 
 <!-- ************Page Break******************* -->

--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@ main design goal.</p>
 
 <p>The following normative documents contain provisions which,
 through reference in this text, constitute provisions of this
-specification. For dated references, subsequent
+International Standard. For dated references, subsequent
 amendments to, or revisions of, any of these publications do not
 apply. However, parties to agreements based on this International
 Standard are encouraged to investigate the possibility of
@@ -1207,7 +1207,7 @@ transforms the source image into a reference image, then
 transforms the reference image into a PNG image. Depending on the
 type of source image, the transformation from the source image to
 a reference image may require the loss of information. That
-transformation is beyond the scope of this specification.
+transformation is beyond the scope of this International Standard.
 The reference image, however, can always be recovered
 exactly from a PNG datastream.</li>
 
@@ -2261,7 +2261,7 @@ letters.
 this version of PNG.</td>
 <td class="Regular">The significance of the case of the third letter of the chunk
 name is reserved for possible future extension. In this
-specification, all chunk names shall have uppercase
+International Standard, all chunk names shall have uppercase
 third letters.</td>
 </tr>
 
@@ -6467,7 +6467,7 @@ recommendations.</p>
 <p>PNG decoders shall support all valid combinations of bit
 depth, colour type, compression method, filter method, and
 interlace method that are explicitly defined in this
-specification.</p>
+International Standard.</p>
 
 </section>
 


### PR DESCRIPTION
~~Remove remaining "this International Standard", replacing with "this specification".~~

Remove old, confusingly named "Relationship to W3C PNG" section, which was about first to second edition changes and [still exists in PNG Second Edition](https://www.w3.org/TR/2003/REC-PNG-20031110/index.html#F-Relationship) and replace with modern Changes section.

The previous editor and author names, which were also in that old section, are already in the header of the document.