### PR TITLE
Stop using "<a id=" for fragments.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1065,7 +1065,7 @@ The format is defined in [[rfc1950]].</dd>
 <!-- ************Page Break******************* -->
 <section>
 <!-- Maintain a fragment named "3Abbreviations" to preserve incoming links to it -->
-<h2 id="3Abbreviations"><a id="abbreviated-terms">Abbreviated terms</a></h2>
+<h2 id="3Abbreviations">Abbreviated terms</h2>
 
 <dl>
 <dfn>
@@ -1240,8 +1240,7 @@ illustrated in <a href="#image-relationship"></a>.</p>
 
 <figure id="image-relationship">
 <!-- Maintain a fragment named "figure41" to preserve incoming links to it -->
-<a id="figure41"></a>
-<object data="figures/image-relationship.svg" type="image/svg+xml" width="640" height="290">
+<object id="figure41" data="figures/image-relationship.svg" type="image/svg+xml" width="640" height="290">
    <img height="280" width="640" src="png-figures/image-relationship.png" alt="Relationships between
 source, reference, PNG, and display images" />
 </object>
@@ -1255,8 +1254,7 @@ sample depth are illustrated in <a href="#sample-pixel-channel-relationship"></a
 
 <figure id="sample-pixel-channel-relationship">
 <!-- Maintain a fragment named "figure42" to preserve incoming links to it -->
-<a id="figure42"></a>
-<object data="figures/sample-pixel-channel-relationship.svg" type="image/svg+xml" width="640" height="290">
+<object id="figure42" data="figures/sample-pixel-channel-relationship.svg" type="image/svg+xml" width="640" height="290">
   <img height="290" width="640" src="png-figures/sample-pixel-channel-relationship.png" alt="Relationships between
 sample, sample depth, pixel, and channel" />
 </object>
@@ -1343,8 +1341,7 @@ alter the alpha sample depth.</p>
 <!-- ************Page Break******************* -->
 <figure id="reference-to-png-transformation">
 <!-- Maintain a fragment named "figure43" to preserve incoming links to it -->
-<a id="figure43"></a>
-<object data="figures/reference-to-png-transformation.svg" type="image/svg+xml" height="525" width="640">
+<object id="figure43" data="figures/reference-to-png-transformation.svg" type="image/svg+xml" height="525" width="640">
 <img height="525" width="640" src="png-figures/reference-to-png-transformation.png" alt="Reference image to PNG
 image transformation" />
 </object>
@@ -1365,7 +1362,7 @@ equivalent image that can be encoded more compactly.</p>
 
 <!-- Maintain a fragment named "4Concepts.Indexing" to preserve incoming links to it -->
 <section id="4Concepts.Indexing">
-<h2><a id="indexing">Indexing</a></h2>
+<h2>Indexing</h2>
 
 <p>If the number of distinct pixel values is 256 or less, and the
 RGB sample depths are not greater than 8, and the alpha channel
@@ -1382,8 +1379,7 @@ samples.</p>
 <!-- ************Page Break******************* -->
 <figure id="indexed-colour-image">
 <!-- Maintain a fragment named "figure44" to preserve incoming links to it -->
-<a id="figure44"></a>
-<object height="450" width="660" data="figures/indexed-colour-image.svg" type="image/svg+xml">
+<object id="figure44" height="450" width="660" data="figures/indexed-colour-image.svg" type="image/svg+xml">
   <img height="450" width="660" src="png-figures/indexed-colour-image.png" alt="Indexed-colour
 image" />
 </object>
@@ -1443,8 +1439,7 @@ be mapped into samples of depth 4.</p>
 <!-- ************Page Break******************* -->
 <figure id="scaling-sample-values">
 <!-- Maintain a fragment named "figure45" to preserve incoming links to it -->
-<a id="figure45"></a>
-<object height="320" width="640" data="figures/scaling-sample-values.svg" type="image/svg+xml">
+<object id="figure45" height="320" width="640" data="figures/scaling-sample-values.svg" type="image/svg+xml">
   <img height="320" width="640" src="png-figures/scaling-sample-values.png" alt="Scaling sample
 values" />
 </object>
@@ -1464,8 +1459,7 @@ rescaling</span></a>.</p>
 
 <figure id="possible-pixel-types">
 <!-- Maintain a fragment named "figure46" to preserve incoming links to it -->
-<a id="figure46"></a>
-<object height="450" width="660" data="figures/possible-pixel-types.svg" type="image/svg+xml">
+<object id="figure46" height="450" width="660" data="figures/possible-pixel-types.svg" type="image/svg+xml">
   <img  height="450" width="660" src= "png-figures/possible-pixel-types.png" alt="Possible PNG image
 pixel types" />
 </object>
@@ -1588,8 +1582,7 @@ illustrated in <a href="#3passExtraction"></a>. See clause&#160;8: <a href="#int
 <!-- ************Page Break******************* -->
 <figure id="encoding-png-image">
 <!-- Maintain a fragment named "figure47" to preserve incoming links to it -->
-<a id="figure47"></a>
-<object height="575" width="645" data="figures/encoding-png-image.svg" type="image/svg+xml">
+<object id="figure47" height="575" width="645" data="figures/encoding-png-image.svg" type="image/svg+xml">
 	<img height="575" width="645" src="png-figures/encoding-png-image.png" alt="Encoding the PNG
 image" />
 </object>
@@ -1599,8 +1592,7 @@ image" />
 
 <figure id="pass-extraction">
 <!-- Maintain a fragment named "figure48" to preserve incoming links to it -->
-<a id="figure48"></a>
-<object height="450" width="645" data="figures/pass-extraction.svg" type="image/svg+xml">
+<object id="figure48" height="450" width="645" data="figures/pass-extraction.svg" type="image/svg+xml">
 	<img height="450" width="645" src="png-figures/pass-extraction.png" alt="Pass extraction" />
 </object>
 <figcaption>Pass extraction</figcaption>
@@ -1636,8 +1628,7 @@ each scanline in a reduced image. See clause&#160;9: <a href=
 
 <figure id="serializing-and-filtering-scanline">
 <!-- Maintain a fragment named "figure49" to preserve incoming links to it -->
-<a id="figure49"></a>
-<object height="340" width="710" data="figures/serializing-and-filtering-scanline.svg" type="image/svg+xml">
+<object id="figure49" height="340" width="710" data="figures/serializing-and-filtering-scanline.svg" type="image/svg+xml">
   <img height="340" width="710" src="png-figures/serializing-and-filtering-scanline.png" alt="Serializing and
 filtering a scanline" />
 </object>
@@ -1670,8 +1661,7 @@ redundancy check. See clause&#160;11: <a href="#chunk-specifications"><span clas
 <!-- ************Page Break******************* -->
 <figure id="compression">
 <!-- Maintain a fragment named "figure410" to preserve incoming links to it -->
-<a id="figure410"></a>
-<object height="450" width="700" data="figures/compression.svg" type="image/svg+xml">
+<object id="figure410" height="450" width="700" data="figures/compression.svg" type="image/svg+xml">
  <img height="450" width="700" src="png-figures/compression.png" alt="Compression" />
 </object>
 <figcaption>Compression</figcaption>
@@ -2122,8 +2112,7 @@ The chunk data field may be empty.</p>
 
 <figure id="chunk-parts">
 <!-- Maintain a fragment named "figure411" to preserve incoming links to it -->
-<a id="figure411"></a>
-<object height="160" width="480" data="figures/chunk-parts.svg" type="image/svg+xml">
+<object id="figure411" height="160" width="480" data="figures/chunk-parts.svg" type="image/svg+xml">
  <img height="160" width="480" src="png-figures/chunk-parts.png" alt="Chunk parts" />
 </object>
 <figcaption>Chunk parts</figcaption>
@@ -2582,8 +2571,7 @@ symbols used in lattice diagrams</b></caption>
 <!-- ************Page Break******************* -->
 <figure id="lattice-diagram-with-plte">
 <!-- Maintain a fragment named "figure52" to preserve incoming links to it -->
-<a id="figure52"></a>
-<object height="540" width="800" data="figures/lattice-diagram-with-plte.svg" type="image/svg+xml">
+<object id="figure52" height="540" width="800" data="figures/lattice-diagram-with-plte.svg" type="image/svg+xml">
  <img height="540" width="800" src="png-figures/lattice-diagram-with-plte.png" alt="Lattice diagram: static PNG images with PLTE in datastream" />
 </object>
 <figcaption>Lattice diagram: PNG images with <a href="#plte-palette"><span class=
@@ -2593,8 +2581,7 @@ symbols used in lattice diagrams</b></caption>
 
 <figure id="lattice-diagram-without-plte">
 <!-- Maintain a fragment named "figure53" to preserve incoming links to it -->
-<a id="figure53"></a>
-<object height="540" width="900" data="figures/lattice-diagram-without-plte.svg"
+<object id="figure53" height="540" width="900" data="figures/lattice-diagram-without-plte.svg"
 type="image/svg+xml">
  <img height="540" width="900" src="png-figures/lattice-diagram-without-plte.png" alt="Lattice diagram: static PNG images without PLTE in datastream" />
 </object>
@@ -2865,8 +2852,7 @@ with the value -2<sup>31</sup>.</p>
 
 <figure id="integer-representation-in-png">
 <!-- Maintain a fragment named "figure71" to preserve incoming links to it -->
-<a id="figure71"></a>
-<object height="310" width="810" data="figures/integer-representation-in-png.svg" type="image/svg+xml">
+<object id="figure71" height="310" width="810" data="figures/integer-representation-in-png.svg" type="image/svg+xml">
   <img height="310" width="810" src="png-figures/integer-representation-in-png.png" alt="Integer representation in PNG" />
 </object>
 <figcaption>Integer representation in PNG</figcaption>
@@ -3225,8 +3211,7 @@ logic of the function and the locations of the bytes <tt>a</tt>,
 <!-- ************Page Break******************* -->
 <figure id="paethpredictor-function">
 <!-- Maintain a fragment named "9-figure91" to preserve incoming links to it -->
-<a id="9-figure91"></a>
-<object height="360" width="640" data="figures/paethpredictor-function.svg" type="image/svg+xml">
+<object id="9-figure91" height="360" width="640" data="figures/paethpredictor-function.svg" type="image/svg+xml">
   <img height="360" width="640" src="png-figures/paethpredictor-function.png" alt="The PaethPredictor
 function" />
 </object>
@@ -3680,7 +3665,7 @@ PNG datastream. The chunk's data field is empty.</p>
 
 <!-- Maintain a fragment named "11Ancillary-chunks" to preserve incoming links to it -->
 <section id="11Ancillary-chunks">
-<h2><a id="ancillary-chunks">Ancillary chunks</a></h2>
+<h2>Ancillary chunks</h2>
 
 <!-- Maintain a fragment named "11AcGen" to preserve incoming links to it -->
 <section class="introductory" id="11AcGen">
@@ -4144,8 +4129,8 @@ sample bits of all channels are to be treated as significant.</p>
 
 <!-- Maintain a fragment named "11sRGB" to preserve incoming links to it -->
 <section id="11sRGB">
-<h2><a id="srgb-standard-colour-space"><span class="chunk">sRGB</span>
-Standard RGB colour space</a></h2>
+<h2 id="srgb-standard-colour-space"><span class="chunk">sRGB</span>
+Standard RGB colour space</h2>
 
 <p>The four decimal values below correspond to the four-byte sRGB chunk type field:</p>
 
@@ -4633,8 +4618,8 @@ chunk.</p>
 
 <!-- Maintain a fragment named "11tEXt" to preserve incoming links to it -->
 <section id="11tEXt">
-<h2><a id="text-textual-data"><span class="chunk">tEXt</span>
-Textual data</a></h2>
+<h2 id="text-textual-data"><span class="chunk">tEXt</span>
+Textual data</h2>
 
 <p>The four-byte chunk type field contains the decimal values</p>
 
@@ -7886,9 +7871,9 @@ to assume that the chunk will remain somewhere between <a href=
 
 <!-- ************Page Break******************* -->
 <!-- ************Page Break******************* -->
-<section id="conformance">
 <!-- Maintain a fragment named "15Conformance" to preserve incoming links to it -->
-<a id="15Conformance"></a>
+<div id="15Conformance"></div>
+<section id="conformance">
 
 <!-- Maintain a fragment named "15ConfIntro" to preserve incoming links to it -->
 <section id="15ConfIntro">
@@ -8508,21 +8493,21 @@ display environment in order to achieve, or approximate, the
 desired display output.</p>
 
 <p>Additional information about this subject may be found in the
-references <a href="#GAMMA-TUTORIAL"><span class=
+references <a href="#G-GAMMA-TUTORIAL"><span class=
 "bibref">[GAMMA-TUTORIAL]</span></a>, <a href=
-"#GAMMA-FAQ"><span class="bibref">[GAMMA-FAQ]</span></a>, and
-<a href="#POYNTON"><span class="bibref">[POYNTON]</span></a>
+"#G-GAMMA-FAQ"><span class="bibref">[GAMMA-FAQ]</span></a>, and
+<a href="#G-POYNTON"><span class="bibref">[POYNTON]</span></a>
 (especially chapter 6).</p>
 
 <p>Background information about chromaticity and colour spaces
-may be found in references <a href="#COLOUR-TUTORIAL"><span
+may be found in references <a href="#G-COLOUR-TUTORIAL"><span
 class="bibref">[COLOUR-TUTORIAL]</span></a>, <a href=
-"#COLOUR-FAQ"><span class="bibref">[COLOUR-FAQ]</span></a>, <a
-href="#HALL"><span class="bibref">[HALL]</span></a>, <a href=
-"#KASSON"><span class="bibref">[KASSON]</span></a>, <a href=
-"#LILLEY"><span class="bibref">[LILLEY]</span></a>, <a href=
-"#STONE"><span class="bibref">[STONE]</span></a>, and <a href=
-"#TRAVIS"><span class="bibref">[TRAVIS]</span></a>.</p>
+"#G-COLOUR-FAQ"><span class="bibref">[COLOUR-FAQ]</span></a>, <a
+href="#G-HALL"><span class="bibref">[HALL]</span></a>, <a href=
+"#G-KASSON"><span class="bibref">[KASSON]</span></a>, <a href=
+"#G-LILLEY"><span class="bibref">[LILLEY]</span></a>, <a href=
+"#G-STONE"><span class="bibref">[STONE]</span></a>, and <a href=
+"#G-TRAVIS"><span class="bibref">[TRAVIS]</span></a>.</p>
 </section>
 
 <!-- ************Page Break******************* -->
@@ -8702,7 +8687,7 @@ Sample viewer and encoder applications of libpng are available at
 <a href=
 "http://www.libpng.org/pub/png/book/sources.html"><code>http://www.libpng.org/pub/png/book/sources.html</code></a>
 and are described in detail in <i>PNG: The Definitive Guide</i>
-<a href="#ROELOFS">[ROELOFS]</a>. Test images can also be
+<a href="#G-ROELOFS">[ROELOFS]</a>. Test images can also be
 accessed from the PNG web site.</p>
 </section>
 </section>
@@ -8714,12 +8699,12 @@ accessed from the PNG web site.</p>
 
 <p>This specification is strongly based on W3C
 Recommendation PNG Specification Version 1.0 <a href=
-"#PNG-1.0">[PNG-1.0]</a> which was reviewed by W3C members,
+"#G-PNG-1.0">[PNG-1.0]</a> which was reviewed by W3C members,
 approved as a W3C Recommendation, and published in October 1996
 according to the established W3C process. Subsequent amendments
 to the PNG Specification have also been incorporated into this
-International Standard <a href="#PNG-1.0">[PNG-1.1]</a>, <a
-href="#PNG-1.0">[PNG-1.2]</a>.</p>
+International Standard <a href="#G-PNG-1.0">[PNG-1.1]</a>, <a
+href="#G-PNG-1.0">[PNG-1.2]</a>.</p>
 
 <p>A complete review of the document has been done by ISO/IEC/JTC
 1/SC 24 in collaboration with W3C in order to transform this
@@ -8921,8 +8906,7 @@ Bibliography</h2>
 
 <dl>
 <!-- Maintain a fragment named "G-COLOUR-FAQ" to preserve incoming links to it -->
-<dt id="G-COLOUR-FAQ">
-<a id="COLOUR-FAQ">[COLOUR-FAQ]</a></dt>
+<dt id="G-COLOUR-FAQ">[COLOUR-FAQ]</dt>
 
 <dd>Poynton, C., "Colour FAQ".<br class="xhtml" />
  <a href=
@@ -8930,8 +8914,7 @@ Bibliography</h2>
 <code>http://www.poynton.com/ColorFAQ.html</code></a></dd>
 
 <!-- Maintain a fragment named "G-COLOUR-TUTORIAL" to preserve incoming links to it -->
-<dt id="G-COLOUR-TUTORIAL">
-<a id="COLOUR-TUTORIAL">[COLOUR-TUTORIAL]</a></dt>
+<dt id="G-COLOUR-TUTORIAL">[COLOUR-TUTORIAL]</dt>
 
 <dd>PNG Group, "Colour tutorial".<br class="xhtml" />
  <a href=
@@ -8939,8 +8922,7 @@ Bibliography</h2>
 http://www.libpng.org/pub/png/spec/1.2/PNG-ColorAppendix.html</code></a></dd>
 
 <!-- Maintain a fragment named "G-GAMMA-TUTORIAL" to preserve incoming links to it -->
-<dt id="G-GAMMA-TUTORIAL">
-<a id="GAMMA-TUTORIAL">[GAMMA-TUTORIAL]</a></dt>
+<dt id="G-GAMMA-TUTORIAL">[GAMMA-TUTORIAL]</dt>
 
 <dd>PNG Group, "Gamma tutorial".<br class="xhtml" />
  <a href=
@@ -8948,8 +8930,7 @@ http://www.libpng.org/pub/png/spec/1.2/PNG-ColorAppendix.html</code></a></dd>
 http://www.libpng.org/pub/png/spec/1.2/PNG-GammaAppendix.html</code></a></dd>
 
 <!-- Maintain a fragment named "G-GAMMA-FAQ" to preserve incoming links to it -->
-<dt id="G-GAMMA-FAQ">
-<a id="GAMMA-FAQ">[GAMMA-FAQ]</a></dt>
+<dt id="G-GAMMA-FAQ">[GAMMA-FAQ]</dt>
 
 <dd>Poynton, C., "Gamma FAQ".<br class="xhtml" />
  <a href=
@@ -8957,31 +8938,27 @@ http://www.libpng.org/pub/png/spec/1.2/PNG-GammaAppendix.html</code></a></dd>
 <code>http://www.poynton.com/Poynton-color.html</code></a></dd>
 
 <!-- Maintain a fragment named "G-HALL" to preserve incoming links to it -->
-<dt id="G-HALL">
-<a id="HALL">[HALL]</a></dt>
+<dt id="G-HALL">[HALL]</dt>
 
 <dd>Hall, Roy, <i>Illumination and Color in Computer Generated
 Imagery</i>. Springer-Verlag, New York, 1989. ISBN
 0-387-96774-5.</dd>
 
 <!-- Maintain a fragment named "G-ICC" to preserve incoming links to it -->
-<dt id="G-ICC">
-<a id="ICC">[ICC]</a></dt>
+<dt id="G-ICC">[ICC]</dt>
 
 <dd>The International Color Consortium.<br class="xhtml" />
  <a href=
 "http://www.color.org/"><code>http://www.color.org/</code></a></dd>
 
 <!-- Maintain a fragment named "G-ISO-3664" to preserve incoming links to it -->
-<dt id="G-ISO-3664">
-<a id="ISO-3664">[ISO-3664]</a></dt>
+<dt id="G-ISO-3664">[ISO-3664]</dt>
 
 <dd>ISO 3664:2000, <i>Viewing conditions &mdash; Graphic
 technology and photography</i>.</dd>
 
 <!-- Maintain a fragment named "G-ITU-R-BT.709" to preserve incoming links to it -->
-<dt id="G-ITU-R-BT.709">
-<a id="ITU-R BT.709">[ITU-R BT.709]</a></dt>
+<dt id="G-ITU-R-BT.709">[ITU-R BT.709]</dt>
 
 <dd>International Telecommunications Union, <i>Basic Parameter
 Values for the HDTV Standard for the Studio and for International
@@ -8989,24 +8966,21 @@ Programme Exchange</i>, ITU-R Recommendation BT.709 (formerly CCIR
 Rec. 709), 1990.</dd>
 
 <!-- Maintain a fragment named "G-ITU-T-V42" to preserve incoming links to it -->
-<dt id="G-ITU-T-V42">
-<a id="ITU-T-V42">[ITU-T-V42]</a></dt>
+<dt id="G-ITU-T-V42">[ITU-T-V42]</dt>
 
 <dd>International Telecommunications Union, <i>Error-correcting
 Procedures for DCEs Using Asynchronous-to-Synchronous
 Conversion</i>, ITU-T Recommendation V.42, 1994, Rev. 1.</dd>
 
 <!-- Maintain a fragment named "G-KASSON" to preserve incoming links to it -->
-<dt id="G-KASSON">
-<a id="KASSON">[KASSON]</a></dt>
+<dt id="G-KASSON">[KASSON]</dt>
 
 <dd>Kasson, J., and W. Plouffe, "An Analysis of Selected Computer
 Interchange Color Spaces", <i>ACM Transactions on Graphics</i>,
 vol. 11, no. 4 , pp. 373-405, 1992.</dd>
 
 <!-- Maintain a fragment named "G-LILLEY" to preserve incoming links to it -->
-<dt id="G-LILLEY">
-<a id="LILLEY">[LILLEY]</a></dt>
+<dt id="G-LILLEY">[LILLEY]</dt>
 
 <dd>Lilley, C., F. Lin, W.T. Hewitt, and T.L.J. Howard, <i>Colour
 in Computer Graphics</i>. CVCP, Sheffield, 1993. ISBN
@@ -9017,8 +8991,7 @@ in Computer Graphics</i>. CVCP, Sheffield, 1993. ISBN
 --></dd>
 
 <!-- Maintain a fragment named "G-ROELOFS" to preserve incoming links to it -->
-<dt id="G-ROELOFS">
-<a id="ROELOFS">[ROELOFS]</a></dt>
+<dt id="G-ROELOFS">[ROELOFS]</dt>
 
 <dd>Roelofs, G., <i>PNG: The Definitive Guide</i>, O'Reilly &amp;
 Associates Inc, Sebastopol, CA, 1999. ISBN 1-56592-542-4.
@@ -9027,16 +9000,14 @@ See also <a href="http://www.libpng.org/pub/png/pngbook.html">
 </a></dd>
 
 <!-- Maintain a fragment named "G-PAETH" to preserve incoming links to it -->
-<dt id="G-PAETH">
-<a id="PAETH">[PAETH]</a></dt>
+<dt id="G-PAETH">[PAETH]</dt>
 
 <dd>Paeth, A.W., "Image File Compression Made Easy", in
 <i>Graphics Gems II</i>, James Arvo, editor. Academic Press, San
 Diego, 1991. ISBN 0-12-064480-0.</dd>
 
 <!-- Maintain a fragment named "G-PNG-1.0" to preserve incoming links to it -->
-<dt id="G-PNG-1.0">
-<a id="PNG-1.0">[PNG-1.0]</a></dt>
+<dt id="G-PNG-1.0">[PNG-1.0]</dt>
 
 <dd>W3C Recommendation, "PNG (Portable Network Graphics)
 Specification, Version 1.0", 1996. Available in several formats
@@ -9048,8 +9019,7 @@ and from<br class="xhtml" />
 "http://www.libpng.org/pub/png/spec/1.0/"><code>http://www.libpng.org/pub/png/spec/1.0/</code></a></dd>
 
 <!-- Maintain a fragment named "G-PNG-1.1" to preserve incoming links to it -->
-<dt id="G-PNG-1.1">
-<a id="PNG-1.1">[PNG-1.1]</a></dt>
+<dt id="G-PNG-1.1">[PNG-1.1]</dt>
 
 <dd>PNG Development Group, "PNG (Portable Network Graphics)
 Specification, Version 1.1", 1999. Available
@@ -9058,8 +9028,7 @@ from<br class="xhtml" />
 "http://www.libpng.org/pub/png/spec/1.1/"><code>http://www.libpng.org/pub/png/spec/1.1/</code></a></dd>
 
 <!-- Maintain a fragment named "G-PNG-1.2" to preserve incoming links to it -->
-<dt id="G-PNG-1.2">
-<a id="PNG-1.2">[PNG-1.2]</a></dt>
+<dt id="G-PNG-1.2">[PNG-1.2]</dt>
 
 <dd>PNG Development Group, "PNG (Portable Network Graphics)
 Specification, Version 1.2", 1999. Available from<br class="xhtml" />
@@ -9067,8 +9036,7 @@ Specification, Version 1.2", 1999. Available from<br class="xhtml" />
 "http://www.libpng.org/pub/png/spec/1.2/"><code>http://www.libpng.org/pub/png/spec/1.2/</code></a></dd>
 
 <!-- Maintain a fragment named "G-PNG-EXTENSIONS" to preserve incoming links to it -->
-<dt id="G-PNG-EXTENSIONS">
-<a id="PNG-EXTENSIONS">[PNG-EXTENSIONS]</a></dt>
+<dt id="G-PNG-EXTENSIONS">[PNG-EXTENSIONS]</dt>
 
 <dd>PNG Working Group, "Register of PNG Public Chunks and Keywords".
 Available  from:<br class="xhtml" />
@@ -9076,55 +9044,48 @@ Available  from:<br class="xhtml" />
 "https://w3c.github.io/PNG-spec/extensions/Overview.html"><code>https://w3c.github.io/PNG-spec/extensions/Overview.html</code></a></dd>
 
 <!-- Maintain a fragment named "G-POSTSCRIPT" to preserve incoming links to it -->
-<dt id="G-POSTSCRIPT">
-<a id="POSTSCRIPT">[POSTSCRIPT]</a></dt>
+<dt id="G-POSTSCRIPT">[POSTSCRIPT]</dt>
 
 <dd>Adobe Systems Incorporated, <i>PostScript Language Reference
 Manual</i>, 2nd edition. Addison-Wesley, Reading, 1990. ISBN
 0-201-18127-4.</dd>
 
 <!-- Maintain a fragment named "G-POYNTON" to preserve incoming links to it -->
-<dt id="G-POYNTON">
-<a id="POYNTON">[POYNTON]</a></dt>
+<dt id="G-POYNTON">[POYNTON]</dt>
 
 <dd>Poynton, Charles A., <i>A Technical Introduction to Digital
 Video</i>. John Wiley and Sons, Inc., New York, 1996. ISBN
 0-471-12253-X.</dd>
 
 <!-- Maintain a fragment named "G-SMPTE-170M" to preserve incoming links to it -->
-<dt id="G-SMPTE-170M">
-<a id="SMPTE 170M">[SMPTE 170M]</a></dt>
+<dt id="G-SMPTE-170M">[SMPTE 170M]</dt>
 
 <dd>Society of Motion Picture and Television Engineers,
 <i>Television &mdash; Composite Analog Video Signal &mdash; NTSC
 for Studio Applications</i>, SMPTE 170M, 1994.</dd>
 
 <!-- Maintain a fragment named "G-STONE" to preserve incoming links to it -->
-<dt id="G-STONE">
-<a id="STONE">[STONE]</a></dt>
+<dt id="G-STONE">[STONE]</dt>
 
 <dd>Stone, M.C., W.B. Cowan, and J.C. Beatty, "Color gamut
 mapping and the printing of digital images", <i>ACM Transactions on
 Graphics</i>, vol. 7, no. 3, pp. 249-292, 1988.</dd>
 
 <!-- Maintain a fragment named "G-TIFF-6.0" to preserve incoming links to it -->
-<dt id="G-TIFF-6.0">
-<a id="TIFF 6.0">[TIFF 6.0]</a></dt>
+<dt id="G-TIFF-6.0">[TIFF 6.0]</dt>
 
 <dd>TIFF<sup>TM</sup> Revision 6.0, Aldus Corporation, June
 1992.</dd>
 
 <!-- Maintain a fragment named "G-TRAVIS" to preserve incoming links to it -->
-<dt id="G-TRAVIS">
-<a id="TRAVIS">[TRAVIS]</a></dt>
+<dt id="G-TRAVIS">[TRAVIS]</dt>
 
 <dd>Travis, David, <i>Effective Color Displays &mdash; Theory and
 Practice</i>. Academic Press, London, 1991. ISBN
 0-12-697690-2.</dd>
 
 <!-- Maintain a fragment named "G-ZL" to preserve incoming links to it -->
-<dt id="G-ZL">
-<a id="ZL">[ZL]</a></dt>
+<dt id="G-ZL">[ZL]</dt>
 
 <dd>J. Ziv and A. Lempel, "A Universal Algorithm for Sequential
 Data Compression", <i>IEEE Transactions on Information


### PR DESCRIPTION
The previous PNG spec used "<a name=" for fragments. This was changed to
"<a id=" to become HTML-conformant.

However, ReSpec wants all anchor tags to link to a destination rather
than be an empty tag.

This commit removes empty anchor tags by placing the ids on more correct
tags.

Note, ReSpec requires `<section id="conformance">` which prevents using
the old id. Any tag after this section will come below ReSpec's
generated conformance introduction. So an empty `<div>` is created above
the section to preserve the old id/fragment.