### PR TITLE
Fix linking to figure

### DIFF
--- a/index.html
+++ b/index.html
@@ -1571,7 +1571,7 @@ datastream.</li>
 <h2>Pass
 extraction</h2>
 
-<p>Pass extraction (see <a href="#3passExtraction"></a>) splits a PNG image into a
+<p>Pass extraction (see [[[#encoding-png-image]]]) splits a PNG image into a
 sequence of reduced images where the first image defines a coarse
 view and subsequent images enhance this coarse view until the
 last image completes the PNG image. The set of reduced images is
@@ -1581,7 +1581,7 @@ null method; pixels are stored sequentially from left to right
 and scanlines from top to bottom. The second method makes
 multiple scans over the image to produce a sequence of seven
 reduced images. The seven passes for a sample image are
-illustrated in <a href="#3passExtraction"></a>. See clause&#160;8: <a href="#interlacing-and-pass-extraction"><span class=
+illustrated in [[[#encoding-png-image]]]. See clause&#160;8: <a href="#interlacing-and-pass-extraction"><span class=
 "xref">Interlacing and pass extraction</span></a>.</p>
 
 <!-- ************Page Break******************* -->


### PR DESCRIPTION
Currently, two links to a figure are broken. ReSpec is erroring on this.

This commit fixes those broken links.