### PR TITLE
fix up broken structure (missing two closing section tags)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2071,6 +2071,7 @@ available for private use.
 </p>
 </section>
 </section>
+</section>
 
 <!-- Maintain a fragment named "5DataRep" to preserve incoming links to it -->
 <section id="5DataRep">
@@ -5676,7 +5677,7 @@ the image data are changed.</p>
   </section>
 </section>
 
-
+</section>
 </section>
 
 <!-- ************Page Break******************* -->


### PR DESCRIPTION
The table of contents was broken, putting much of the spec into section 5! This was caused by two missing `</section>` which this PR fixes.