### PR TITLE
Add iccn chunk2

### DIFF
--- a/index.html
+++ b/index.html
@@ -1828,9 +1828,11 @@ image.</td>
   <li>Colour space information: <a href="#chrm-primary-chromaticities-and-white-point"><span class=
   "chunk">cHRM</span></a>, <a href="#gama-image-gamma"><span class=
   "chunk">gAMA</span></a>, <a href="#iccp-embedded-icc-profile"><span class=
-  "chunk">iCCP</span></a>, <a href="#sbit-significant-bits"><span class=
+  "chunk">iCCP</span></a>, <a href="#iccn-embedded-icc-profile"><span class=
+  "chunk">iCCN</span></a>, <a href="#sbit-significant-bits"><span class=
   "chunk">sBIT</span></a>, <a href="#srgb-standard-rgb-colour-space"><span class=
-  "chunk">sRGB</span></a> (see [[#colour-space-information]]).</li>
+    "chunk">sRGB</span></a>, <a href="#cicp-video-rendering-colour-spaces"><span class=
+      "chunk">cICP</span></a> (see [[#colour-space-information]]).</li>
 
   <li>Textual information: <a href="#itxt-international-textual-data"><span class=
   "chunk">iTXt</span></a>, <a href="#text-textual-data"><span class=
@@ -2439,6 +2441,16 @@ present, the <a href="#srgb-standard-rgb-colour-space"><span class=
 </tr>
 
 <tr>
+  <td class="Regular"><a href="#iccn-embedded-icc-profile"><span class="chunk">iCCN</span></a> </td>
+  <td class="Regular">No</td>
+  <td class="Regular">Before <a href="#11PLTE"><span class="chunk">PLTE</span></a>
+  and <a href="#idat-image-data"><span class="chunk">IDAT</span></a>. If the
+  <a href="#iccn-embedded-icc-profile"><span class="chunk">iCCN</span></a> chunk is
+  present, the <a href="#srgb-standard-rgb-colour-space"><span class=
+  "chunk">sRGB</span></a> chunk should not be present.</td>
+  </tr>
+
+<tr>
 <td class="Regular"><a href="#sbit-significant-bits"><span class="chunk">sBIT</span></a> </td>
 <td class="Regular">No</td>
 <td class="Regular">Before <a href="#11PLTE"><span class="chunk">PLTE</span></a>
@@ -2452,7 +2464,8 @@ and <a href="#idat-image-data"><span class="chunk">IDAT</span></a> </td>
 and <a href="#idat-image-data"><span class="chunk">IDAT</span></a>. If the
 <a href="#srgb-standard-rgb-colour-space"><span class="chunk">sRGB</span></a> chunk is
 present, the <a href="#iccp-embedded-icc-profile"><span class=
-"chunk">iCCP</span></a> chunk should not be present.</td>
+"chunk">iCCP</span></a> and <a href="#iccn-embedded-icc-profile"><span class=
+  "chunk">iCCN</span></a>chunks should not be present.</td>
 </tr>
 
 <tr>
@@ -2757,7 +2770,8 @@ space is indicated (by <a href="#gama-image-gamma"><span class=
 "chunk">gAMA</span></a> and <a href="#chrm-primary-chromaticities-and-white-point"><span class=
 "chunk">cHRM</span></a>, or <a href="#srgb-standard-rgb-colour-space"><span class=
 "chunk">sRGB</span></a>, or <a href="#iccp-embedded-icc-profile"><span class=
-"chunk">iCCP</span></a>) or uncalibrated device-dependent colour
+"chunk">iCCP</span></a>, <a href="#iccn-embedded-icc-profile"><span class=
+  "chunk">iCCN</span></a> or uncalibrated device-dependent colour
 if not.</p>
 
 <p>Sample values are not necessarily proportional to light
@@ -3362,7 +3376,8 @@ compression</h2>
 
 <p>PNG also uses compression method 0 in <a href="#itxt-international-textual-data"><span
 class="chunk">iTXt</span></a>, <a href="#iccp-embedded-icc-profile"><span class=
-"chunk">iCCP</span></a>, and <a href="#ztxt-compressed-textual-data"><span class=
+"chunk">iCCP</span></a>, <a href="#iccn-embedded-icc-profile"><span class=
+  "chunk">iCCN</span></a>, and <a href="#ztxt-compressed-textual-data"><span class=
 "chunk">zTXt</span></a> chunks. Unlike the image data, such
 datastreams are not split across chunks; each such chunk contains
 an independent zlib datastream (see 10.1: <a href=
@@ -3821,7 +3836,8 @@ specify the 1931 CIE <i>x,y</i> chromaticities of the red,
 green, and blue display primaries used in the image, and the referenced
 white point. See Annex C: <a href="#C-GammaAppendix"><span class=
 "xref">Gamma and chromaticity</span></a> for more information.
-The <a href="#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a> and <a
+The <a href="#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a>, 
+<a href="#iccn-embedded-icc-profile"><span class="chunk">iCCN</span></a>, and <a
 href="#srgb-standard-rgb-colour-space"><span class="chunk">sRGB</span></a> chunks provide
 more sophisticated support for colour management and control.</p>
 
@@ -3882,8 +3898,9 @@ representing the <i>x</i> or <i>y</i> value times 100000.</p>
 PNG datastreams, although it is of little value for greyscale
 images.</p>
 
-<p>An <a href="#srgb-standard-rgb-colour-space"><span class="chunk">sRGB</span></a> chunk
-or <a href="#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a> chunk,
+<p>An <a href="#srgb-standard-rgb-colour-space"><span class="chunk">sRGB</span></a>, 
+<a href="#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a>, or 
+<a href="#iccn-embedded-icc-profile"><span class="chunk">iCCN</span></a> chunk
 when present and recognized, overrides the <span class=
 "chunk">cHRM</span> chunk.</p>
 </section>
@@ -3913,8 +3930,9 @@ Adjustment for different viewing conditions is normally handled
 by a Colour Management System. If the adjustment is not
 performed, the error is usually small. Applications desiring high
 colour fidelity may wish to use an <a href="#srgb-standard-rgb-colour-space"><span class=
-"chunk">sRGB</span></a> chunk or <a href="#iccp-embedded-icc-profile"><span class=
-"chunk">iCCP</span></a> chunk.</p>
+"chunk">sRGB</span></a>, <a href="#iccp-embedded-icc-profile"><span class=
+"chunk">iCCP</span></a>, or <a href="#iccn-embedded-icc-profile"><span class=
+  "chunk">iCCN</span></a> chunk.</p>
 
 <p>The <span class="chunk">gAMA</span> chunk contains:</p>
 
@@ -3937,8 +3955,9 @@ representing gamma times 100000.</p>
 "#decoder-gamma-handling"><span class="xref">Decoder gamma
 handling</span></a> for more information.</p>
 
-<p>An <a href="#srgb-standard-colour-space"><span class="chunk">sRGB</span></a> chunk
-or <a href="#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a> chunk,
+<p>An <a href="#srgb-standard-colour-space"><span class="chunk">sRGB</span></a>,
+<a href="#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a>, or
+<a href="#iccN-embedded-icc-profile"><span class="chunk">iCCN</span></a> chunk,
 when present and recognized, overrides the <span class=
 "chunk">gAMA</span> chunk.</p>
 </section>
@@ -4019,10 +4038,10 @@ full-fledged colour management should use the <a href=
 "#chrm-primary-chromaticitieis-and-white-point"><span class="chunk">cHRM</span></a> chunks if
 present.</p>
 
-<p>A PNG datastream should contain at most one embedded profile,
-whether specified explicitly with an <span class=
-"chunk">iCCP</span> chunk or implicitly with an <a href=
-"#srgb-standard-colour-space"><span class="chunk">sRGB</span></a> chunk.</p>
+<p>Unless a cICP chunk exists, a PNG datastream should contain at most one embedded profile,
+whether specified explicitly with an <span class="chunk">iCCP</span>, 
+<span class="chunk">iCCN</span>, or implicitly with an 
+<a href="#srgb-standard-colour-space"><span class="chunk">sRGB</span></a> chunk.</p>
 </section>
 
 <!-- Maintain a fragment named "11sBIT" to preserve incoming links to it -->
@@ -4278,9 +4297,10 @@ values given above as if they had appeared in <a href=
 "#gama-image-gamma"><span class="chunk">gAMA</span></a> and <a href=
 "#chrm-primary-chromaticities-and-white-point"><span class="chunk">cHRM</span></a> chunks.</p>
 
-<p>It is recommended that the <span class="chunk">sRGB</span> and
-<a href="#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a> chunks do
-not both appear in a PNG datastream.</p>
+<p>It is recommended that the <span class="chunk">sRGB</span>,
+<a href="#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a>, or 
+<a href="#iccn-embedded-icc-profile"><span class="chunk">iCCN</span></a> chunks do
+not appear simultaneously in a PNG datastream.</p>
 </section>
 
 <!-- Maintain a fragment named "11cICP" to preserve incoming links to it -->
@@ -4401,10 +4421,11 @@ benefit from the existence of sub-blacks or super-whites.
 </table>
 <p>The cICP chunk must come before the IDAT chunk.</p>
 
-<p>When the cICP chunk is present, PNG decoders that recognize it shall ignore
-the following chunks:</p>
+<p>When the cICP chunk is present, PNG decoders with attached displays that support it
+  shall ignore the following chunks:</p>
 <ul>
   <li>iCCP</li>
+  <li>ICCN </li>
   <li>gAMA </li>
   <li>cHRM </li>
   <li>sRGB </li>
@@ -4488,7 +4509,61 @@ decoder should be capable of producing the proper rendering intent as described 
 [[ITU-T H.273]] and
 it's associated recommendations.</p>
 </section>
-</section>
+
+<!-- Maintain a fragment named "11iCCN" to preserve incoming links to it -->
+<section id="11iCCN">
+  <h2><span class="chunk">iCCN</span>
+    Embedded ICC Profiles v4 and UTF-8 Profile Names</h2>
+  
+    <p>iCCN profiles are the same is iCCP chunks but can support UTF-8 Profile
+      Names</p>
+    
+    <p>The four decimal values below correspond to the four-byte iCCN chunk type field:</p>
+    
+    <pre>
+    105 67 67 78
+    </pre>
+    
+    <p>The <span class="chunk">iCCN</span> chunk contains:</p>
+    
+    <table class="Regular" summary=
+    "This table defines the iCCP chunk">
+    <tr>
+    <td class="Regular">Profile name</td>
+    <td class="Regular">UTF-8 (character string)</td>
+    </tr>
+    
+    <tr>
+    <td class="Regular">Null separator</td>
+    <td class="Regular">1 byte (null character)</td>
+    </tr>
+    
+    <tr>
+    <td class="Regular">Compression method</td>
+    <td class="Regular">1 byte</td>
+    </tr>
+    
+    <tr>
+    <td class="Regular">Compressed profile</td>
+    <td class="Regular">n bytes</td>
+    </tr>
+    </table>
+    
+    <p>The iCCN profile name may be any convenient name for referring to
+    the profile. It is case-sensitive. Profile names shall contain printable 
+    Latin-1 characters, spaces and includes UTF-8 characters.  Leading, trailing,
+    and consecutive spaces are not permitted.</p>
+  
+    <p>PNG files should not simultaneously contain embedded iCCP and iCCN tags.</p>
+  
+    <p>The iCCN chunk shall take precedence over a <a class='Href' href='#11cICP'>
+      cICP</a> chunk if the display/graphics plane does not support the explicit 
+      codepoints specified in cICP with formulas referenced in <a href="#2-ITU-T-H.273"><span 
+        class="NormRef">[ITU-T H.273]</span></a><a</td></a>. </p>
+  </section>
+
+
+
 
 <!-- Maintain a fragment named "11textinfo" to preserve incoming links to it -->
 <section id="11textinfo">
@@ -5705,15 +5780,17 @@ to gamma issues.</p>
 <p>PNG encoders capable of full colour management will perform more
 sophisticated calculations than those described here and may
 choose to use the <a href="#iccp-embedded-icc-profile"><span class=
-"chunk">iCCP</span></a> chunk. If it is known that the image
+"chunk">iCCP</span></a> or <a href="#iccN-embedded-icc-profile"><span class=
+  "chunk">iCCN</span></a> chunks (but not both). If it is known that the image
 samples conform to the sRGB specification [[SRGB]], encoders are strongly encouraged to write
 the <a href="#srgb-standard-colour-space"><span class="chunk">sRGB</span></a> chunk
 without performing additional gamma handling. In both cases it is
 recommended that an appropriate <a href="#gama-image-gamma"><span class=
 "chunk">gAMA</span></a> chunk be generated for use by PNG
 decoders that do not recognize the <a href="#iccp-embedded-icc-profile"><span class=
-"chunk">iCCP</span></a> chunk or <a href="#srgb-standard-colour-space"><span class=
-"chunk">sRGB</span></a> chunk.</p>
+"chunk">iCCP</span></a>, <a href="#iccN-embedded-icc-profile"><span class=
+  "chunk">iCCN</span></a>, or <a href="#srgb-standard-colour-space"><span class=
+"chunk">sRGB</span></a> chunks.</p>
 
 <p>A PNG encoder has to determine:</p>
 
@@ -5898,7 +5975,8 @@ issues.</p>
 <p>PNG encoders capable of full colour management will perform more
 sophisticated calculations than those described here and may
 choose to use the <a href="#iccp-embedded-icc-profile"><span class=
-"chunk">iCCP</span></a> chunk. If it is known that the image
+"chunk">iCCP</span></a> and <a href="#iccn-embedded-icc-profile"><span class=
+  "chunk">iCCN</span></a> chunks. If it is known that the image
 samples conform to the sRGB specification [[SRGB]], PNG encoders are strongly encouraged to
 use the <a href="#srgb-standard-colour-space"><span class="chunk">sRGB</span></a>
 chunk.</p>
@@ -6620,7 +6698,8 @@ checking</span></a>).</p>
 "chunk">IDAT</span></a>, <a href="#ztxt-compressed-textual-data"><span class=
 "chunk">zTXt</span></a>, <a href="#itxt-international-textual-data"><span class=
 "chunk">iTXt</span></a>, <a href="#iccp-embedded-icc-profile"><span class=
-"chunk">iCCP</span></a>) could lead to buffer overruns.
+"chunk">iCCP</span></a>), <a href="#iccn-embedded-icc-profile"><span class=
+  "chunk">iCCN</span></a>) could lead to buffer overruns.
 Implementors of deflate decompressors should guard against this
 possibility.</p>
 
@@ -6720,9 +6799,9 @@ href="#text-textual-data"><span class="chunk">tEXt</span></a>, and <a href=
 "#ztxt-compressed-textual-data"><span class="chunk">zTXt</span></a> chunks contain keywords
 and data
 that are meant to be displayed as plain text. The <a href=
-"#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a> and <a href=
-"#splt-suggested-palette"><span class="chunk">sPLT</span></a> chunks contain
-keywords that are meant to be displayed as plain text. It is
+"#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a>, "#iccn-embedded-icc-profile">
+<span class="chunk">iCCN</span></a>, and <a href= "#splt-suggested-palette"><span class="chunk">
+sPLT</span></a> chunks contain keywords that are meant to be displayed as plain text. It is
 possible that if the decoder displays such text without filtering
 out control characters, especially the ESC (escape) character,
 certain systems or terminals could behave in undesirable and
@@ -7216,10 +7295,10 @@ precomputed table of logarithms. Example code appears in [[PNG-EXTENSIONS]].</p>
 
 <p>When the incoming image has unknown gamma (<a href=
 "#gama-image-gamma"><span class="chunk">gAMA</span></a>, <a href=
-"#srgb-standard-colour-space"><span class="chunk">sRGB</span></a>, and <a href=
-"#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a> all absent),
-standalone image viewers should
-choose
+"#srgb-standard-colour-space"><span class="chunk">sRGB</span></a>, <a href=
+"#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a>, and 
+<a href="#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a> 
+all absent), standalone image viewers should choose
 a likely default gamma value, but allow the user to select a new
 one if the result proves too dark or too light. The default gamma
 may depend on other knowledge about the image, for example
@@ -7975,7 +8054,7 @@ specified in this specification.</li>
 <li>No chunks appear in the PNG datastream other than those
 specified in this specification or those defined
 according to the rules for creating new chunk types as defined in
-this International Standard.</li>
+this specification.</li>
 
 <li>The PNG datastream is encoded according to the rules of this
 International Standard.</li>
@@ -7989,7 +8068,7 @@ International Standard.</li>
 <h2>Conformance of PNG
 encoders</h2>
 
-<p>A PNG encoder conforms to this International Standard if it
+<p>A PNG encoder conforms to this specification if it
 satisfies the following conditions.</p>
 
 <!-- <ol start="1"> --><ol>
@@ -8013,7 +8092,7 @@ fields.</li>
 <h2>Conformance of PNG
 decoders</h2>
 
-<p>A PNG decoder conforms to this International Standard if it
+<p>A PNG decoder conforms to this specification if it
 satisfies the following conditions.</p>
 
 <!-- <ol start="1"> --><ol>
@@ -8080,7 +8159,7 @@ ordering rules.</li>
 <h2>Conformance of PNG
 editors</h2>
 
-<p>A PNG editor conforms to this International Standard if it satisfies the following conditions.</p>
+<p>A PNG editor conforms to this specification if it satisfies the following conditions.</p>
 
 <ol>
 <li>It conforms to the requirements for PNG encoders.</li>

--- a/index.html
+++ b/index.html
@@ -1831,8 +1831,8 @@ image.</td>
   "chunk">iCCP</span></a>, <a href="#iccn-embedded-icc-profile"><span class=
   "chunk">iCCN</span></a>, <a href="#sbit-significant-bits"><span class=
   "chunk">sBIT</span></a>, <a href="#srgb-standard-rgb-colour-space"><span class=
-    "chunk">sRGB</span></a>, <a href="#cicp-video-rendering-colour-spaces"><span class=
-      "chunk">cICP</span></a> (see [[#colour-space-information]]).</li>
+  "chunk">sRGB</span></a>, <a href="#cicp-video-rendering-colour-spaces"><span class=
+  "chunk">cICP</span></a> (see [[#colour-space-information]]).</li>
 
   <li>Textual information: <a href="#itxt-international-textual-data"><span class=
   "chunk">iTXt</span></a>, <a href="#text-textual-data"><span class=
@@ -3957,7 +3957,7 @@ handling</span></a> for more information.</p>
 
 <p>An <a href="#srgb-standard-colour-space"><span class="chunk">sRGB</span></a>,
 <a href="#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a>, or
-<a href="#iccN-embedded-icc-profile"><span class="chunk">iCCN</span></a> chunk,
+<a href="#iccn-embedded-icc-profile"><span class="chunk">iCCN</span></a> chunk,
 when present and recognized, overrides the <span class=
 "chunk">gAMA</span> chunk.</p>
 </section>
@@ -4421,8 +4421,8 @@ benefit from the existence of sub-blacks or super-whites.
 </table>
 <p>The cICP chunk must come before the IDAT chunk.</p>
 
-<p>When the cICP chunk is present, PNG decoders with attached displays that support it
-  shall ignore the following chunks:</p>
+<p>When the cICP chunk is present, PNG decoders that recognize it shall ignore
+the following chunks:</p>
 <ul>
   <li>iCCP</li>
   <li>ICCN </li>
@@ -4510,12 +4510,11 @@ decoder should be capable of producing the proper rendering intent as described 
 it's associated recommendations.</p>
 </section>
 
-<!-- Maintain a fragment named "11iCCN" to preserve incoming links to it -->
-<section id="11iCCN">
+<section>
   <h2><span class="chunk">iCCN</span>
     Embedded ICC Profiles v4 and UTF-8 Profile Names</h2>
   
-    <p>iCCN profiles are the same is iCCP chunks but can support UTF-8 Profile
+    <p>iCCN profiles are the same as iCCP chunks but can support UTF-8 Profile
       Names</p>
     
     <p>The four decimal values below correspond to the four-byte iCCN chunk type field:</p>
@@ -4551,11 +4550,8 @@ it's associated recommendations.</p>
     
     <p>The iCCN profile name may be any convenient name for referring to
     the profile. It is case-sensitive. Profile names shall contain printable 
-    Latin-1 characters, spaces and includes UTF-8 characters.  Leading, trailing,
-    and consecutive spaces are not permitted.</p>
-  
-    <p>PNG files should not simultaneously contain embedded iCCP and iCCN tags.</p>
-  
+    characters.  Leading, trailing, and consecutive spaces are not permitted.</p>
+   
     <p>The iCCN chunk shall take precedence over a <a class='Href' href='#11cICP'>
       cICP</a> chunk if the display/graphics plane does not support the explicit 
       codepoints specified in cICP with formulas referenced in <a href="#2-ITU-T-H.273"><span 
@@ -5780,7 +5776,7 @@ to gamma issues.</p>
 <p>PNG encoders capable of full colour management will perform more
 sophisticated calculations than those described here and may
 choose to use the <a href="#iccp-embedded-icc-profile"><span class=
-"chunk">iCCP</span></a> or <a href="#iccN-embedded-icc-profile"><span class=
+"chunk">iCCP</span></a> or <a href="#iccn-embedded-icc-profile"><span class=
   "chunk">iCCN</span></a> chunks (but not both). If it is known that the image
 samples conform to the sRGB specification [[SRGB]], encoders are strongly encouraged to write
 the <a href="#srgb-standard-colour-space"><span class="chunk">sRGB</span></a> chunk
@@ -5788,7 +5784,7 @@ without performing additional gamma handling. In both cases it is
 recommended that an appropriate <a href="#gama-image-gamma"><span class=
 "chunk">gAMA</span></a> chunk be generated for use by PNG
 decoders that do not recognize the <a href="#iccp-embedded-icc-profile"><span class=
-"chunk">iCCP</span></a>, <a href="#iccN-embedded-icc-profile"><span class=
+"chunk">iCCP</span></a>, <a href="#iccn-embedded-icc-profile"><span class=
   "chunk">iCCN</span></a>, or <a href="#srgb-standard-colour-space"><span class=
 "chunk">sRGB</span></a> chunks.</p>
 
@@ -6799,7 +6795,7 @@ href="#text-textual-data"><span class="chunk">tEXt</span></a>, and <a href=
 "#ztxt-compressed-textual-data"><span class="chunk">zTXt</span></a> chunks contain keywords
 and data
 that are meant to be displayed as plain text. The <a href=
-"#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a>, "#iccn-embedded-icc-profile">
+"#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a>, <a href="#iccn-embedded-icc-profile">
 <span class="chunk">iCCN</span></a>, and <a href= "#splt-suggested-palette"><span class="chunk">
 sPLT</span></a> chunks contain keywords that are meant to be displayed as plain text. It is
 possible that if the decoder displays such text without filtering
@@ -7297,7 +7293,7 @@ precomputed table of logarithms. Example code appears in [[PNG-EXTENSIONS]].</p>
 "#gama-image-gamma"><span class="chunk">gAMA</span></a>, <a href=
 "#srgb-standard-colour-space"><span class="chunk">sRGB</span></a>, <a href=
 "#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a>, and 
-<a href="#iccp-embedded-icc-profile"><span class="chunk">iCCP</span></a> 
+<a href="#iccn-embedded-icc-profile"><span class="chunk">iCCN</span></a> 
 all absent), standalone image viewers should choose
 a likely default gamma value, but allow the user to select a new
 one if the result proves too dark or too light. The default gamma


### PR DESCRIPTION
This is a duplicate of Chris Lilley's iCCN pull request https://github.com/w3c/PNG-spec/pull/117 .
This pull request squashes several commits down and addresses some of the code review comments.

It does not yet address iCCM concerns (or adding the #iccn-embedded-icc-profile fragment). Once we confirm iCCM is an option for us, I'll address those.