### PR TITLE
Fix mismatched tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2617,7 +2617,7 @@ class="chunk">PLTE</span></a> in datastream</figcaption>
 <section id="sec-defining-public-chunks">
   <h3>General</h3>
 
-  <p>All chunks, private and public, SHOULD be listed at [[PNG-EXTENSIONS]].</a>
+  <p>All chunks, private and public, SHOULD be listed at [[PNG-EXTENSIONS]].</p>
 
 </section>
 


### PR DESCRIPTION
There is an opening <p> tag followed by a closing </a> tag. These are
mismatched.

This commit replaces the closing </a> tag with the </p> tag it was
supposed to be.