### PR TITLE
Fix references to use ReSpec and SpecRef

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,12 @@
         date: "2021",
         href: "https://w3c.github.io/PNG-spec/extensions/Overview.html"
       },
+      "SMPTE 170M": {
+        title: "Television — Composite Analog Video Signal — NTSC for Studio Applications",
+        publisher: "Society of Motion Picture and Television Engineers",
+        date: "2004-11-30",
+        href: "https://standards.globalspec.com/std/892300/SMPTE%20ST%20170M"
+      },
       "Ziv-Lempel": {
         authors: ["J. Ziv", "A. Lempel"],
         title: "A Universal Algorithm for Sequential Data Compression, IEEE Transactions on Information Theory, vol. IT-23, no. 3, pp. 337 - 343",
@@ -8872,13 +8878,6 @@ Manual</i>, 2nd edition. Addison-Wesley, Reading, 1990. ISBN
 <dd>Poynton, Charles A., <i>A Technical Introduction to Digital
 Video</i>. John Wiley and Sons, Inc., New York, 1996. ISBN
 0-471-12253-X.</dd>
-
-<!-- Maintain a fragment named "G-SMPTE-170M" to preserve incoming links to it -->
-<dt id="G-SMPTE-170M">[SMPTE 170M]</dt>
-
-<dd>Society of Motion Picture and Television Engineers,
-<i>Television &mdash; Composite Analog Video Signal &mdash; NTSC
-for Studio Applications</i>, SMPTE 170M, 1994.</dd>
 
 <!-- Maintain a fragment named "G-STONE" to preserve incoming links to it -->
 <dt id="G-STONE">[STONE]</dt>

--- a/index.html
+++ b/index.html
@@ -292,21 +292,6 @@ IEC maintain registers of currently valid International
 Standards.</p>
 
 
-<!-- Maintain a fragment named "2-ICC-1" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-ICC-1">ICC-1, International
-Color Consortium, "Specification ICC.1:2010-12 (Profile version 4.3.0.0)
-Image technology colour management - Architecture, profile format, and data structure,
-available at <code><a href=
-"http://www.color.org/icc_specs2.xalter">http://www.color.org/icc_specs2.xalter</a></code>
-also published as ISO 15076-1</p>
-
-<!-- Maintain a fragment named "2-ICC-a" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-ICC-a">ICC-2,
-International Color Consortium, "Specification ICC.2:2019 (iccMAX)
-Image technology colour management - Extensions to architecture, profile format, and data structure,
-available at <code><a href=
-"http://www.color.org/icc_specs2.xalter">http://www.color.org/icc_specs2.xalter</a></code>
-also published as ISO 20677-1</p>
 
 <!-- Maintain a fragment named "2-RFC-1123" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-RFC-1123">RFC-1123, Braden,

--- a/index.html
+++ b/index.html
@@ -273,29 +273,7 @@ datastream and associated file format have value outside of the
 main design goal.</p>
 </section>
 
-<!-- ************Page Break******************* -->
-<!-- ************Page Break******************* -->
-<section>
-<!-- Maintain a fragment named "2NormRefs" to preserve incoming links to it -->
-<h2 id="2NormRefs">Normative references</h2>
 
-<p>The following normative documents contain provisions which,
-through reference in this text, constitute provisions of this
-International Standard. For dated references, subsequent
-amendments to, or revisions of, any of these publications do not
-apply. However, parties to agreements based on this International
-Standard are encouraged to investigate the possibility of
-applying the most recent editions of the normative documents
-indicated below. For undated references, the latest edition of
-the normative document referred to applies. Members of ISO and
-IEC maintain registers of currently valid International
-Standards.</p>
-
-
-</section>
-
-<!-- ************Page Break******************* -->
-<!-- ************Page Break******************* -->
 <section>
 <!-- Maintain a fragment named "3Defsandabbrevs" to preserve incoming links to it -->
 <h2 id="3Defsandabbrevs">Terms, definitions, and

--- a/index.html
+++ b/index.html
@@ -292,15 +292,6 @@ IEC maintain registers of currently valid International
 Standards.</p>
 
 
-<!-- Maintain a fragment named "2-ISO-8859-1" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-ISO-8859-1">ISO/IEC
-8859-1:1998, <i>Information technology &mdash; 8-bit
-single-byte coded graphic character sets &mdash; Part 1: Latin
-alphabet No. 1</i>.<br class="xhtml" />
- For convenience, here is a non-normative  <a href="iso_8859-1.txt">sample text file</a>
- describing the codes and associated character names.</p>
-
-
 <!-- Maintain a fragment named "2-IEC-61966-2-1" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-IEC-61966-2-1">IEC
 61966-2-1, <i>Multimedia systems and equipment &mdash; Colour

--- a/index.html
+++ b/index.html
@@ -279,10 +279,6 @@ the normative document referred to applies. Members of ISO and
 IEC maintain registers of currently valid International
 Standards.</p>
 
-<!-- Maintain a fragment named "2-ISO-639" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-ISO-639">ISO 639:1988,
-<i>Code for the representation of names of languages</i>.</p>
-
 <!-- Maintain a fragment named "2-ISO-646" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-ISO-646">ISO/IEC 646:1991,
 <i>International Organization for Standardization, Information
@@ -4823,7 +4819,7 @@ the text. Unlike the keyword, the language tag is
 case-insensitive. It is an ISO 646.IRV:1991 [[ISO 646]] string consisting of
 hyphen-separated words of 1-8 alphanumeric characters each (for example cn,
 en-uk, no-bok, x-klingon, x-KlInGoN). If the first word is two or three
-letters long, it is an ISO language code [[ISO 639]]. If the
+letters long, it is an ISO language code [[BCP47]]. If the
 language tag is empty, the language is unspecified.</p>
 
 <p>The translated keyword and text both use the UTF-8 encoding [[rfc3629]],

--- a/index.html
+++ b/index.html
@@ -292,14 +292,6 @@ IEC maintain registers of currently valid International
 Standards.</p>
 
 
-<!-- Maintain a fragment named "2-ITU-T-H.273" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-ITU-T-H.273">ITU-T H.273,
-SERIES H: AUDIOVISUAL AND MULTIMEDIA SYSTEMS
-Infrastructure of audiovisual services – Coding of moving video
-Coding-independent code points for video signal type identification<br class="xhtml" />
- <code><a href=
-"https://www.itu.int/rec/T-REC-H.273">https://www.itu.int/rec/T-REC-H.273</a></code></p>
-
 <!-- Maintain a fragment named "2-ITU-R-BT.2100" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-ITU-R-BT.2100">ITU-R BT.2100,
 SERIES H: AUDIOVISUAL AND MULTIMEDIA SYSTEMS

--- a/index.html
+++ b/index.html
@@ -292,20 +292,6 @@ IEC maintain registers of currently valid International
 Standards.</p>
 
 
-<!-- Maintain a fragment named "2-RFC-1950" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-RFC-1950">RFC-1950, Deutsch,
-P. and Gailly, J-L., "ZLIB Compressed Data Format Specification
-version 3.3", RFC 1950, Aladdin Enterprises, May 1996.<br class="xhtml" />
- <code><a href=
-"http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a></code></p>
-
-<!-- Maintain a fragment named "2-RFC-1951" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-RFC-1951">RFC-1951, Deutsch,
-P., "DEFLATE Compressed Data Format Specification version 1.3",
-RFC 1951, Aladdin Enterprises, May 1996.<br class="xhtml" />
- <code><a href=
-"http://www.ietf.org/rfc/rfc1951.txt">http://www.ietf.org/rfc/rfc1951.txt</a></code></p>
-
 <!-- Maintain a fragment named "2-RFC-2045" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-RFC-2045">RFC-2045, Freed,
 N. and Borenstein, N. , "MIME (Multipurpose Internet Mail

--- a/index.html
+++ b/index.html
@@ -279,11 +279,6 @@ the normative document referred to applies. Members of ISO and
 IEC maintain registers of currently valid International
 Standards.</p>
 
-<!-- Maintain a fragment named "2-ISO-646" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-ISO-646">ISO/IEC 646:1991,
-<i>International Organization for Standardization, Information
-technology &mdash; ISO 7-bit coded character set for information
-interchange</i>.</p>
 
 <!-- Maintain a fragment named "2-ISO-3309" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-ISO-3309">ISO/IEC 3309:1993</a>,
@@ -303,11 +298,6 @@ alphabet No. 1</i>.<br class="xhtml" />
 <p class="NormRefDef" id="2-ISO-9899">ISO/IEC
 9899:1990(R1997), <i>Programming languages &mdash; C</i>.</p>
 
-<!-- Maintain a fragment named "2-ISO-10656-1" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-ISO-10646-1">ISO/IEC
-10646-1:1993/AMD.2, <i>Information technology &mdash;
-Universal Multiple-Octet Coded Character Sets (UCS) &mdash; Part
-1: Architecture and Basic Multilingual Plane</i>.</p>
 
 <!-- Maintain a fragment named "2-IEC-61966-2-1" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-IEC-61966-2-1">IEC
@@ -1779,7 +1769,7 @@ image.</td>
 
   <p>There are 19 chunk types defined in this International
   Standard. Chunk types are four-byte sequences chosen so that they
-  correspond to readable labels when interpreted in the ISO 646.IRV:1991
+  correspond to readable labels when interpreted in the ISO 646.IRV:1991 [[ISO646]]
   character set. The first four are termed critical chunks, which
   shall be understood and correctly interpreted according to the
   provisions of this specification. These are:</p>
@@ -2125,7 +2115,7 @@ should treat the length as unsigned, its value shall not exceed
 <td class="Regular">A sequence of four bytes defining the chunk type. Each byte
 of a chunk type is restricted to the decimal values 65 to 90 and
 97 to 122. These correspond to the uppercase and lowercase ISO
-646 letters (<tt>A</tt>-<tt>Z</tt> and <tt>a</tt>-<tt>z</tt>)
+646 [[ISO646]] letters (<tt>A</tt>-<tt>Z</tt> and <tt>a</tt>-<tt>z</tt>)
 respectively for convenience in description and examination of
 PNG datastreams. Encoders and decoders shall treat the chunk
 types as fixed binary values, not character strings. For example,
@@ -2164,7 +2154,7 @@ aligned on any boundaries larger than bytes.</p>
 <h2>Chunk naming conventions</h2>
 
 <p>Chunk types are chosen to be meaningful names when the bytes
-of the chunk type are interpreted as ISO 646 letters. Chunk types
+of the chunk type are interpreted as ISO 646 letters [[ISO646]]. Chunk types
 are assigned so that a decoder can determine some properties of a
 chunk even when the type is not recognized. These rules allow
 safe, flexible extension of the PNG format, by allowing a PNG
@@ -4816,7 +4806,7 @@ it.</p>
 <p>The language tag defined in [[rfc3066]]
 indicates the human language used by the translated keyword and
 the text. Unlike the keyword, the language tag is
-case-insensitive. It is an ISO 646.IRV:1991 [[ISO 646]] string consisting of
+case-insensitive. It is an ISO 646.IRV:1991 [[ISO646]] string consisting of
 hyphen-separated words of 1-8 alphanumeric characters each (for example cn,
 en-uk, no-bok, x-klingon, x-KlInGoN). If the first word is two or three
 letters long, it is an ISO language code [[BCP47]]. If the

--- a/index.html
+++ b/index.html
@@ -292,14 +292,6 @@ IEC maintain registers of currently valid International
 Standards.</p>
 
 
-<!-- Maintain a fragment named "2-RFC-2048" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-RFC-2048">RFC-2048, Freed,
-N., Klensin, J. and Postel, J., "Multipurpose Internet Mail
-Extensions (MIME) Part Four: Registration Procedures", RFC 2048,
-Innosoft, MCI, ISI, November 1996.<br class="xhtml" />
- <code><a href=
-"http://www.ietf.org/rfc/rfc2048.txt">http://www.ietf.org/rfc/rfc2048.txt</a></code></p>
-
 <!-- Maintain a fragment named "2-RFC-3066" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-RFC-3066">RFC-3066,
 Alvestrand, H., "Tags for the Identification of Languages", RFC

--- a/index.html
+++ b/index.html
@@ -292,13 +292,6 @@ IEC maintain registers of currently valid International
 Standards.</p>
 
 
-<!-- Maintain a fragment named "2-ITU-R-BT.709" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-ITU-R-BT.709">ITU-R BT.709,
-SERIES H: AUDIOVISUAL AND MULTIMEDIA SYSTEMS
-Infrastructure of audiovisual services – Coding of moving video
-Coding-independent code points for video signal type identification<br class="xhtml" />
- <code><a href=
-"https://www.itu.int/rec/R-REC-BT.709">https://www.itu.int/rec/R-REC-BT.709</a></code></p>
 </section>
 
 <!-- ************Page Break******************* -->
@@ -4329,7 +4322,7 @@ with the HLG transfer function, Matrix Coefficients (using RGB Identity)and Full
 9 18 0 1
 </pre>
 
-<p>Here is an example of source content that uses BT.709 colour primaries,
+<p>Here is an example of source content that uses BT.709 colour primaries [[ITU-R BT.709]],
 with the BT.709 transfer function, Matrix Coefficients (using RGB Identity)and Full-Range signal scaling</p>
 
 <pre>
@@ -8678,13 +8671,6 @@ Imagery</i>. Springer-Verlag, New York, 1989. ISBN
 <dd>ISO 3664:2000, <i>Viewing conditions &mdash; Graphic
 technology and photography</i>.</dd>
 
-<!-- Maintain a fragment named "G-ITU-R-BT.709" to preserve incoming links to it -->
-<dt id="G-ITU-R-BT.709">[ITU-R BT.709]</dt>
-
-<dd>International Telecommunications Union, <i>Basic Parameter
-Values for the HDTV Standard for the Studio and for International
-Programme Exchange</i>, ITU-R Recommendation BT.709 (formerly CCIR
-Rec. 709), 1990.</dd>
 
 <!-- Maintain a fragment named "G-ITU-T-V42" to preserve incoming links to it -->
 <dt id="G-ITU-T-V42">[ITU-T-V42]</dt>

--- a/index.html
+++ b/index.html
@@ -292,16 +292,6 @@ IEC maintain registers of currently valid International
 Standards.</p>
 
 
-
-<!-- Maintain a fragment named "2-RFC-1123" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-RFC-1123">RFC-1123, Braden,
-R., Editor, "Requirements for Internet Hosts &mdash; Application
-and Support", STD 3, RFC 1123, USC/Information Sciences
-Institute, October 1989.<br class="xhtml" />
- <code><a href=
-"http://www.ietf.org/rfc/rfc1123.txt">http://www.ietf.org/rfc/rfc1123.txt</a></code>
-</p>
-
 <!-- Maintain a fragment named "2-RFC-1950" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-RFC-1950">RFC-1950, Deutsch,
 P. and Gailly, J-L., "ZLIB Compressed Data Format Specification

--- a/index.html
+++ b/index.html
@@ -292,14 +292,6 @@ IEC maintain registers of currently valid International
 Standards.</p>
 
 
-<!-- Maintain a fragment named "2-RFC-2045" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-RFC-2045">RFC-2045, Freed,
-N. and Borenstein, N. , "MIME (Multipurpose Internet Mail
-Extensions) Part One: Format of Internet Message Bodies", RFC
-2045, Innosoft, First Virtual, November 1996.<br class="xhtml" />
- <code><a href=
-"http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a></code></p>
-
 <!-- Maintain a fragment named "2-RFC-2048" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-RFC-2048">RFC-2048, Freed,
 N., Klensin, J. and Postel, J., "Multipurpose Internet Mail

--- a/index.html
+++ b/index.html
@@ -2379,7 +2379,7 @@ class="chunk">PLTE</span></a> is optional)</th>
 </tr>
 
 <tr>
-<td class="Regular"><span class="chunk">[[acTL]]</span> </td>
+<td class="Regular"><span class="chunk">acTL</span> </td>
 <td class="Regular">No</td>
 <td class="Regular">Before <a href="#11PLTE"><span class="chunk">PLTE</span></a>
 and <a href="#11IDAT"><span class="chunk">IDAT</span></a> </td>

--- a/index.html
+++ b/index.html
@@ -292,12 +292,6 @@ IEC maintain registers of currently valid International
 Standards.</p>
 
 
-<!-- Maintain a fragment named "2-ISO-3309" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-ISO-3309">ISO/IEC 3309:1993</a>,
-<i>Information Technology &mdash; Telecommunications and
-information exchange between systems &mdash; High-level data link
-control (HDLC) procedures &mdash; Frame structure</i>.</p>
-
 <!-- Maintain a fragment named "2-ISO-8859-1" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-ISO-8859-1">ISO/IEC
 8859-1:1998, <i>Information technology &mdash; 8-bit

--- a/index.html
+++ b/index.html
@@ -2940,7 +2940,7 @@ value of byte <tt>y</tt>. <tt>Filt(y)</tt> denotes the value
 after a filter has been applied. <tt>Recon(y)</tt> denotes the
 value after the corresponding reconstruction function has been
 applied. The filter function for the Paeth type
-<tt>PaethPredictor</tt> is defined below.</p>
+<tt>PaethPredictor</tt> [[?Paeth]] is defined below.</p>
 
 <p>Filter method 0 specifies exactly this set of five filter
 types and this shall not be extended.
@@ -8690,13 +8690,6 @@ Associates Inc, Sebastopol, CA, 1999. ISBN 1-56592-542-4.
 See also <a href="http://www.libpng.org/pub/png/pngbook.html">
 <code>http://www.libpng.org/pub/png/pngbook.html</code>
 </a></dd>
-
-<!-- Maintain a fragment named "G-PAETH" to preserve incoming links to it -->
-<dt id="G-PAETH">[PAETH]</dt>
-
-<dd>Paeth, A.W., "Image File Compression Made Easy", in
-<i>Graphics Gems II</i>, James Arvo, editor. Academic Press, San
-Diego, 1991. ISBN 0-12-064480-0.</dd>
 
 <!-- Maintain a fragment named "G-PNG-1.0" to preserve incoming links to it -->
 <dt id="G-PNG-1.0">[PNG-1.0]</dt>

--- a/index.html
+++ b/index.html
@@ -292,13 +292,6 @@ IEC maintain registers of currently valid International
 Standards.</p>
 
 
-<!-- Maintain a fragment named "2-RFC-3066" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-RFC-3066">RFC-3066,
-Alvestrand, H., "Tags for the Identification of Languages", RFC
-3066, Cisco Systems, January 2001. (Obsoletes RFC 1766.)<br class="xhtml" />
- <code><a href=
-"http://www.ietf.org/rfc/rfc3066.txt">http://www.ietf.org/rfc/rfc3066.txt</a></code></p>
-
 <!-- Maintain a fragment named "2-ITU-T-H.273" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-ITU-T-H.273">ITU-T H.273,
 SERIES H: AUDIOVISUAL AND MULTIMEDIA SYSTEMS
@@ -4733,7 +4726,7 @@ only compression method defined in this specification is
 set the compression method to 0, and decoders shall ignore
 it.</p>
 
-<p>The language tag defined in [[rfc3066]]
+<p>The language tag defined in [[BCP47]]
 indicates the human language used by the translated keyword and
 the text. Unlike the keyword, the language tag is
 case-insensitive. It is an ISO 646.IRV:1991 [[ISO646]] string consisting of

--- a/index.html
+++ b/index.html
@@ -92,6 +92,12 @@
         title: "ISO/IEC 8859-1:1998, Information technology — 8-bit single-byte coded graphic character sets — Part 1: Latin alphabet No. 1.",
         date: "1998"
       },
+      "ISO 9899": {
+        title: "ISO/IEC 9899:2018 Information technology — Programming languages — C",
+        href: "https://www.iso.org/standard/74528.html",
+        date: "2018-6",
+        publisher: "ISO"
+      },
       "ISO 15076-1": {
         title: "ISO 15076-1:2010 Image technology colour management — Architecture, profile format and data structure — Part 1: Based on ICC.1:2010",
         href: "https://www.iso.org/standard/54754.html",
@@ -293,10 +299,6 @@ single-byte coded graphic character sets &mdash; Part 1: Latin
 alphabet No. 1</i>.<br class="xhtml" />
  For convenience, here is a non-normative  <a href="iso_8859-1.txt">sample text file</a>
  describing the codes and associated character names.</p>
-
-<!-- Maintain a fragment named "2-ISO-9899" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-ISO-9899">ISO/IEC
-9899:1990(R1997), <i>Programming languages &mdash; C</i>.</p>
 
 
 <!-- Maintain a fragment named "2-IEC-61966-2-1" to preserve incoming links to it -->
@@ -7383,7 +7385,7 @@ should be made without first checking.</p>
 
 <!-- ************Page Break******************* -->
 <!-- ************Page Break******************* -->
-<p>This code is ISO C [[ISO-9899]], with line numbers added for
+<p>This code is ISO C [[ISO 9899]], with line numbers added for
 reference in the comments below.</p>
 
 <pre>

--- a/index.html
+++ b/index.html
@@ -292,14 +292,6 @@ IEC maintain registers of currently valid International
 Standards.</p>
 
 
-<!-- Maintain a fragment named "2-ITU-R-BT.2100" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-ITU-R-BT.2100">ITU-R BT.2100,
-SERIES H: AUDIOVISUAL AND MULTIMEDIA SYSTEMS
-Infrastructure of audiovisual services – Coding of moving video
-Coding-independent code points for video signal type identification<br class="xhtml" />
- <code><a href=
-"https://www.itu.int/rec/R-REC-BT.2100">https://www.itu.int/rec/R-REC-BT.2100</a></code></p>
-
 <!-- Maintain a fragment named "2-ITU-R-BT.709" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-ITU-R-BT.709">ITU-R BT.709,
 SERIES H: AUDIOVISUAL AND MULTIMEDIA SYSTEMS
@@ -4323,7 +4315,7 @@ values for cICP">
 
 
 
-<p>Here is an example of source content that uses the BT.2100 colour primaries,
+<p>Here is an example of source content that uses the BT.2100 colour primaries [[ITU-R BT.2100]],
 with the PQ transfer function, Matrix Coefficients (using RGB Identity)and Full-Range signal scaling</p>
 
 <pre>

--- a/index.html
+++ b/index.html
@@ -145,12 +145,25 @@
         date: "2021",
         href: "https://w3c.github.io/PNG-spec/extensions/Overview.html"
       },
+      "PostScript": {
+        title: "PostScript Language Reference Manual",
+        author: "Adobe Systems Incorporated",
+        publisher: "Addison-Wesley",
+        date: "1990",
+        edition: "2",
+        isbn: "0-201-18127-4"
+      },
       "SMPTE 170M": {
         title: "Television — Composite Analog Video Signal — NTSC for Studio Applications",
         publisher: "Society of Motion Picture and Television Engineers",
         date: "2004-11-30",
         href: "https://standards.globalspec.com/std/892300/SMPTE%20ST%20170M"
       },
+      "TIFF 6.0": {
+        "href": "https://www.loc.gov/preservation/digital/formats/fdd/fdd000022.shtml",
+        "title": "TIFF Revision 6.0",
+        "date": "3 June 1992"
+		  },
       "Ziv-Lempel": {
         authors: ["J. Ziv", "A. Lempel"],
         title: "A Universal Algorithm for Sequential Data Compression, IEEE Transactions on Information Theory, vol. IT-23, no. 3, pp. 337 - 343",
@@ -7158,7 +7171,7 @@ the facilities in Level 2 PostScript to specify image data in
 calibrated RGB space or in a device-independent colour space such
 as XYZ. This will provide better colour fidelity than a simple
 RGB to CMYK conversion. The PostScript Language Reference manual
-[[?POSTSCRIPT]] gives examples. Such decoders
+[[?PostScript]] gives examples. Such decoders
 are responsible for implementing gamut mapping between source RGB
 (specified in the <a href="#chrm-primary-chromaticities-and-white-point"><span class=
 "chunk">cHRM</span></a> chunk) and the target printer. The
@@ -8364,7 +8377,7 @@ implementation</h2>
 
 <p>The following sample code represents a practical
 implementation of the CRC (Cyclic Redundancy Check) employed in
-PNG chunks. (See also ISO 3309 [[ISO 3309]] or ITU-T V.42 [[ITU-T-V42]] for a
+PNG chunks. (See also ISO 3309 [[ISO 3309]] or ITU-T V.42 [[ITU-T V.42]] for a
 formal specification.)</p>
 
 <p>The sample code is in the ISO C [[ISO 9899]] programming language. The
@@ -8650,12 +8663,6 @@ Imagery</i>. Springer-Verlag, New York, 1989. ISBN
 technology and photography</i>.</dd>
 
 
-<!-- Maintain a fragment named "G-ITU-T-V42" to preserve incoming links to it -->
-<dt id="G-ITU-T-V42">[ITU-T-V42]</dt>
-
-<dd>International Telecommunications Union, <i>Error-correcting
-Procedures for DCEs Using Asynchronous-to-Synchronous
-Conversion</i>, ITU-T Recommendation V.42, 1994, Rev. 1.</dd>
 
 <!-- Maintain a fragment named "G-KASSON" to preserve incoming links to it -->
 <dt id="G-KASSON">[KASSON]</dt>
@@ -8728,12 +8735,6 @@ Available  from:<br class="xhtml" />
 <a href=
 "https://w3c.github.io/PNG-spec/extensions/Overview.html"><code>https://w3c.github.io/PNG-spec/extensions/Overview.html</code></a></dd>
 
-<!-- Maintain a fragment named "G-POSTSCRIPT" to preserve incoming links to it -->
-<dt id="G-POSTSCRIPT">[POSTSCRIPT]</dt>
-
-<dd>Adobe Systems Incorporated, <i>PostScript Language Reference
-Manual</i>, 2nd edition. Addison-Wesley, Reading, 1990. ISBN
-0-201-18127-4.</dd>
 
 <!-- Maintain a fragment named "G-POYNTON" to preserve incoming links to it -->
 <dt id="G-POYNTON">[POYNTON]</dt>

--- a/index.html
+++ b/index.html
@@ -292,14 +292,6 @@ IEC maintain registers of currently valid International
 Standards.</p>
 
 
-<!-- Maintain a fragment named "2-IEC-61966-2-1" to preserve incoming links to it -->
-<p class="NormRefDef" id="2-IEC-61966-2-1">IEC
-61966-2-1, <i>Multimedia systems and equipment &mdash; Colour
-measurement and management &mdash; Part 2-1: Default RGB colour
-space &mdash; sRGB,</i> available at <code><a href=
-"http://www.iec.ch">http://www.iec.ch/</a></code>.</p>
-
-
 <!-- Maintain a fragment named "2-ICC-1" to preserve incoming links to it -->
 <p class="NormRefDef" id="2-ICC-1">ICC-1, International
 Color Consortium, "Specification ICC.1:2010-12 (Profile version 4.3.0.0)


### PR DESCRIPTION
- Fix up all normative references marked as _Reference not found._
- Update obsolete references to current versions
- Fix up existing informative references
- Check the old hard-coded Normative Refs section, make sure any remaining ones were actually unused, then delete it
