### PR TITLE
Use Informative References, not hard-coded Bibliography

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,11 +77,23 @@
         date: "2019-05-17",
         publisher: "Camera & Imaging Products Association",
       },
+      "COLOR FAQ": {
+        title: "Color FAQ",
+        author: "Poynton, C.",
+        href: "http://poynton.ca/ColorFAQ.html",
+        date: "2009-10-19"
+      },
       "ICC-2": {
         title: "Specification ICC.2:2019 (Profile version 5.0.0 - iccMAX)",
         date: "2019",
         href: "https://www.color.org/specification/ICC.2-2019.pdf",
         publisher: "International Color Consortium"
+      },
+      "GAMMA FAQ": {
+        title: "Gamma FAQ",
+        author: "Poynton, C.",
+        href: "http://poynton.ca/GammaFAQ.html",
+        date: "1998-08-04"
       },
       "ISO 3309": {
         title: "ISO/IEC 3309:1993, Information Technology — Telecommunications and information exchange between systems — High-level data link control (HDLC) procedures — Frame structure.",
@@ -323,12 +335,12 @@ pixel.</dd>
 <!-- Maintain a fragment named "3alphaCompaction" to preserve incoming links to it -->
 <dt><dfn id="3alphaCompaction">alpha compaction</dfn></dt>
 
-<dd>an implicit representation of transparent 
+<dd>an implicit representation of transparent
 <span class="Definition"><a>pixels</a></span>. If every
 pixel with a specific colour or <span
 class="Definition"><a>greyscale</a></span> value is fully
-transparent and all other pixels are fully opaque, the 
-<span class="Definition"><a>alpha</a></span> 
+transparent and all other pixels are fully opaque, the
+<span class="Definition"><a>alpha</a></span>
 <span class="Definition"><a>channel</a></span> may be
 represented implicitly.</dd>
 
@@ -507,7 +519,7 @@ a stored file at all.</dd>
 <dt>deflate</dt></dfn>
 
 <dd>name of a particular compression algorithm. This algorithm is
-used, in compression mode 0, in conforming 
+used, in compression mode 0, in conforming
 <span class="Definition"><a>PNG
 datastreams</a></span>. Deflate is a member of the <a href=
 "#3LZ77"><span class="Definition">LZ77</span></a> family of
@@ -521,7 +533,7 @@ compression methods. It is defined in [[rfc1951]].</dd>
 <dfn id="3deliveredImage">
 <dt>delivered image</dt></dfn>
 
-<dd>image constructed from a decoded 
+<dd>image constructed from a decoded
 <span class="Definition"><a>PNG
 datastream</a></span>.</dd>
 
@@ -666,8 +678,8 @@ order</a></span> in which the most significant byte comes first,
 then the less significant bytes in descending order of
 significance (<span class=
 "Definition"><a>MSB</a></span> <span class=
-"Definition"><a>LSB</a></span> for two-byte integers, 
-<span class="Definition"><a>MSB</a></span> B2 B1 
+"Definition"><a>LSB</a></span> for two-byte integers,
+<span class="Definition"><a>MSB</a></span> B2 B1
 <span class="Definition"><a>LSB</a></span> for four-byte
 integers).</dd>
 
@@ -686,7 +698,7 @@ integers).</dd>
 "Definition"><a>sample</a></span> values, red, green, and blue,
 which with an <span class=
 "Definition"><a>indexed-colour</a></span> image defines the red,
-green, and blue sample values of the 
+green, and blue sample values of the
 <span class="Definition"><a>reference
 image</a></span>. In other cases, the palette may be a suggested
 palette that viewers may use to present the image on
@@ -712,7 +724,7 @@ progressive display.</dd>
 
 <dd>information stored for a single grid point in an image. A
 pixel consists of (or points to) a sequence of <span class=
-"Definition"><a>samples</a></span> from all 
+"Definition"><a>samples</a></span> from all
 <span class="Definition"><a>channels</a></span>. The
 complete image is a rectangular array of pixels.</dd>
 
@@ -725,7 +737,7 @@ complete image is a rectangular array of pixels.</dd>
 <dt>PNG datastream</dt></dfn>
 
 <dd>result of encoding a <span class=
-"Definition"><a>PNG image</a></span>. A PNG 
+"Definition"><a>PNG image</a></span>. A PNG
 <span class="Definition"><a>datastream</a></span>
 consists of a <span class=
 "Definition"><a>PNG signature</a></span></a> followed by a sequence of
@@ -736,7 +748,7 @@ consists of a <span class=
 <dfn id="3PNGdecoder">
 <dt>PNG decoder</dt></dfn>
 
-<dd>process or device which reconstructs the 
+<dd>process or device which reconstructs the
 <span class="Definition"><a>reference
 image</a></span> from a <span class=
 "Definition"><a>PNG datastream</a></span> and generates a
@@ -749,7 +761,7 @@ corresponding delivered image.</dd>
 <dd>process or device which creates a modification of an existing
 <span class="Definition"><a>PNG
 datastream</a></span>, preserving unmodified ancillary
-information wherever possible, and obeying the 
+information wherever possible, and obeying the
 <span class="Definition"><a>chunk</a></span> ordering
 rules, even for unknown chunk types.</dd>
 
@@ -757,10 +769,10 @@ rules, even for unknown chunk types.</dd>
 <dfn id="3PNGencoder">
 <dt>PNG encoder</dt></dfn>
 
-<dd>process or device which constructs a 
+<dd>process or device which constructs a
 <span class="Definition"><a>reference
 image</a></span> from a <span class=
-"Definition"><a>source image</a></span>, and generates a 
+"Definition"><a>source image</a></span>, and generates a
 <span class="Definition"><a>PNG
 datastream</a></span> representing the reference image.</dd>
 
@@ -804,10 +816,10 @@ four-byte values.</dd>
 <dfn id="3PNGimage">
 <dt>PNG image</dt></dfn>
 
-<dd>result of transformations applied by a 
+<dd>result of transformations applied by a
 <span class="Definition"><a>PNG encoder</a></span> to
 a <span class="Definition"><a>reference
-image</a></span>, in preparation for encoding as a 
+image</a></span>, in preparation for encoding as a
 <span class="Definition"><a>PNG
 datastream</a></span>, and the result of decoding a PNG
 datastream.</dd>
@@ -817,7 +829,7 @@ datastream.</dd>
 <dt>PNG signature</dt></dfn>
 
 <dd>sequence of <span class=
-"Definition"><a>bytes</a></span> appearing at the start of every 
+"Definition"><a>bytes</a></span> appearing at the start of every
 <span class="Definition"><a>PNG
 datastream</a></span>. It differentiates a PNG datastream from
 other types of <span class=
@@ -846,8 +858,8 @@ or four (red, green, blue, <span class=
 "Definition"><a>alpha</a></span>). Every reference image can be
 represented exactly by a <span class=
 "Definition"><a>PNG datastream</a></span> and every PNG datastream
-can be converted into a reference image. Each 
-<span class="Definition"><a>channel</a></span> has a 
+can be converted into a reference image. Each
+<span class="Definition"><a>channel</a></span> has a
 <span class="Definition"><a>sample
 depth</a></span> in the range 1 to 16. All samples in the same
 channel have the same sample depth. Different channels may have
@@ -857,7 +869,7 @@ different sample depths.</dd>
 <dfn id="3RGBmerging">
 <dt>RGB merging</dt></dfn>
 
-<dd>converting an image in which the red, green, and blue 
+<dd>converting an image in which the red, green, and blue
 <span class="Definition"><a>samples</a></span> for
 each <span class="Definition"><a>pixel</a></span>
 have the same value, and the same <span
@@ -879,7 +891,7 @@ class="Definition"><a>pixel</a></span> in an image.</dd>
 <dt>sample depth</dt></dfn>
 
 <dd>number of bits used to represent a <span
-class="Definition"><a>sample</a></span> value. In an 
+class="Definition"><a>sample</a></span> value. In an
 <span class=
 "Definition"><a>indexed-colour</a></span> <span
 class="Definition"><a>PNG image</a></span>, samples are stored in
@@ -895,7 +907,7 @@ image it is the same as the <span class=
 scaling</dt></dfn>
 
 <dd>mapping of a range of <span class=
-"Definition"><a>sample</a></span> values onto the full range of a 
+"Definition"><a>sample</a></span> values onto the full range of a
 <span class="Definition"><a>sample
 depth</a></span> allowed in a <span class=
 "Definition"><a>PNG image</a></span>.</dd>
@@ -905,7 +917,7 @@ depth</a></span> allowed in a <span class=
 <dt>scanline</dt></dfn>
 
 <dd>row of <span class=
-"Definition"><a>pixels</a></span> within an image or 
+"Definition"><a>pixels</a></span> within an image or
 <span class="Definition"><a>interlaced PNG
 image</a></span>.</dd>
 
@@ -932,7 +944,7 @@ class="Definition"><a>PNG encoder</a></span>.</dd>
 <dt>truecolour</dt></dfn>
 
 <dd>image representation in which each <span
-class="Definition"><a>pixel</a></span> is defined by 
+class="Definition"><a>pixel</a></span> is defined by
 <span class="Definition"><a>samples</a></span>,
 representing red, green, and blue intensities and optionally an
 <span class="Definition"><a>alpha</a></span>
@@ -8195,24 +8207,11 @@ used by decoders together with additional information about the
 display environment in order to achieve, or approximate, the
 desired display output.</p>
 
-<p>Additional information about this subject may be found in the
-references <a href="#G-GAMMA-TUTORIAL"><span class=
-"bibref">[GAMMA-TUTORIAL]</span></a>, <a href=
-"#G-GAMMA-FAQ"><span class="bibref">[GAMMA-FAQ]</span></a>, and
-<a href="#G-POYNTON"><span class="bibref">[POYNTON]</span></a>
-(especially chapter 6).</p>
+<p>Additional information about this subject may be found [[?GAMMA FAQ]].</p>
 
 <p>Background information about [=chromaticity=] and colour spaces
-may be found in references [[?Luminance-Chromaticity]]
+may be found in [[?Luminance-Chromaticity]] and [[?COLOR FAQ]].</p>
 
-<a href="#G-COLOUR-TUTORIAL"><span
-class="bibref">[COLOUR-TUTORIAL]</span></a>, <a href=
-"#G-COLOUR-FAQ"><span class="bibref">[COLOUR-FAQ]</span></a>, <a
-href="#G-HALL"><span class="bibref">[HALL]</span></a>, <a href=
-"#G-KASSON"><span class="bibref">[KASSON]</span></a>, <a href=
-"#G-LILLEY"><span class="bibref">[LILLEY]</span></a>, <a href=
-"#G-STONE"><span class="bibref">[STONE]</span></a>, and <a href=
-"#G-TRAVIS"><span class="bibref">[TRAVIS]</span></a>.</p>
 </section>
 
 <!-- ************Page Break******************* -->
@@ -8458,37 +8457,6 @@ see
 Bibliography</h2>
 
 <dl>
-<!-- Maintain a fragment named "G-COLOUR-FAQ" to preserve incoming links to it -->
-<dt id="G-COLOUR-FAQ">[COLOUR-FAQ]</dt>
-
-<dd>Poynton, C., "Colour FAQ".<br class="xhtml" />
- <a href=
-"http://www.poynton.com/ColorFAQ.html">
-<code>http://www.poynton.com/ColorFAQ.html</code></a></dd>
-
-<!-- Maintain a fragment named "G-COLOUR-TUTORIAL" to preserve incoming links to it -->
-<dt id="G-COLOUR-TUTORIAL">[COLOUR-TUTORIAL]</dt>
-
-<dd>PNG Group, "Colour tutorial".<br class="xhtml" />
- <a href=
-"http://www.libpng.org/pub/png/spec/1.2/PNG-ColorAppendix.html"><code>
-http://www.libpng.org/pub/png/spec/1.2/PNG-ColorAppendix.html</code></a></dd>
-
-<!-- Maintain a fragment named "G-GAMMA-TUTORIAL" to preserve incoming links to it -->
-<dt id="G-GAMMA-TUTORIAL">[GAMMA-TUTORIAL]</dt>
-
-<dd>PNG Group, "Gamma tutorial".<br class="xhtml" />
- <a href=
-"http://www.libpng.org/pub/png/spec/1.2/PNG-GammaAppendix.html"><code>
-http://www.libpng.org/pub/png/spec/1.2/PNG-GammaAppendix.html</code></a></dd>
-
-<!-- Maintain a fragment named "G-GAMMA-FAQ" to preserve incoming links to it -->
-<dt id="G-GAMMA-FAQ">[GAMMA-FAQ]</dt>
-
-<dd>Poynton, C., "Gamma FAQ".<br class="xhtml" />
- <a href=
-"http://www.poynton.com/Poynton-color.html">
-<code>http://www.poynton.com/Poynton-color.html</code></a></dd>
 
 <!-- Maintain a fragment named "G-HALL" to preserve incoming links to it -->
 <dt id="G-HALL">[HALL]</dt>

--- a/index.html
+++ b/index.html
@@ -8477,57 +8477,6 @@ see
 
 </section>
 
-<!-- ************Page Break******************* -->
-<!-- ************Page Break******************* -->
-<section class="appendix">
-<!-- Maintain a fragment named "G-References" to preserve incoming links to it -->
-<h2 class="Annex" id="G-References">
-Bibliography</h2>
-
-<dl>
-
-
-<!-- Maintain a fragment named "G-PNG-1.0" to preserve incoming links to it -->
-<dt id="G-PNG-1.0">[PNG-1.0]</dt>
-
-<dd>W3C Recommendation, "PNG (Portable Network Graphics)
-Specification, Version 1.0", 1996. Available in several formats
-from<br class="xhtml" />
- <a href=
-"http://www.w3.org/TR/REC-png-961001"><code>http://www.w3.org/TR/REC-png-961001</code></a>
-and from<br class="xhtml" />
- <a href=
-"http://www.libpng.org/pub/png/spec/1.0/"><code>http://www.libpng.org/pub/png/spec/1.0/</code></a></dd>
-
-<!-- Maintain a fragment named "G-PNG-1.1" to preserve incoming links to it -->
-<dt id="G-PNG-1.1">[PNG-1.1]</dt>
-
-<dd>PNG Development Group, "PNG (Portable Network Graphics)
-Specification, Version 1.1", 1999. Available
-from<br class="xhtml" />
- <a href=
-"http://www.libpng.org/pub/png/spec/1.1/"><code>http://www.libpng.org/pub/png/spec/1.1/</code></a></dd>
-
-<!-- Maintain a fragment named "G-PNG-1.2" to preserve incoming links to it -->
-<dt id="G-PNG-1.2">[PNG-1.2]</dt>
-
-<dd>PNG Development Group, "PNG (Portable Network Graphics)
-Specification, Version 1.2", 1999. Available from<br class="xhtml" />
- <a href=
-"http://www.libpng.org/pub/png/spec/1.2/"><code>http://www.libpng.org/pub/png/spec/1.2/</code></a></dd>
-
-<!-- Maintain a fragment named "G-PNG-EXTENSIONS" to preserve incoming links to it -->
-<dt id="G-PNG-EXTENSIONS">[PNG-EXTENSIONS]</dt>
-
-<dd>PNG Working Group, "Register of PNG Public Chunks and Keywords".
-Available  from:<br class="xhtml" />
-<a href=
-"https://w3c.github.io/PNG-spec/extensions/Overview.html"><code>https://w3c.github.io/PNG-spec/extensions/Overview.html</code></a></dd>
-
-</dl>
-
-
-</section>
 
 <script type="application/javascript" src="https://www.w3.org/scripts/TR/fixup.js"></script></body>
 </html>

--- a/index.html
+++ b/index.html
@@ -95,6 +95,13 @@
         href: "http://poynton.ca/GammaFAQ.html",
         date: "1998-08-04"
       },
+      "Hill": {
+        title: "Comparative analysis of the quantization of color spaces on the basis of the CIELAB color-difference formula",
+        authors: "Hill, B.; Roger, Th., Vorhagen, F.W.",
+        journal: "ACM Transactions on Graphics, Volume 16, Issue 2, pp. 109–154",
+        date: "1997-04",
+        href: "https://dl.acm.org/doi/10.1145/248210.248212"
+      },
       "ISO 3309": {
         title: "ISO/IEC 3309:1993, Information Technology — Telecommunications and information exchange between systems — High-level data link control (HDLC) procedures — Frame structure.",
         date: "1993",
@@ -143,11 +150,18 @@
         date: "2002-03-29",
         publisher: "ITU"
       },
+      "Kasson": {
+        title: "An Analysis of Selected Computer Interchange Color Spaces",
+        authors: "Kasson, J., and W. Plouffe",
+        journal: "ACM Transactions on Graphics, vol. 11, no. 4, pp. 373-405",
+        date: "1992",
+        href: "https://dl.acm.org/doi/abs/10.1145/146443.146479"
+      },
       "Luminance-Chromaticity": {
         title: "Luminance and Chromaticity",
         href: "https://colorusage.arc.nasa.gov/lum_and_chrom.php",
         publisher: "Color Usage Research Lab, NASA Ames Research Center"
-      }
+      },
       "Paeth": {
         author: "Paeth, A.W",
         title: "Image File Compression Made Easy, in Graphics Gems II, pp. 93-100",
@@ -8217,6 +8231,11 @@ desired display output.</p>
 
 <p>Additional information about this subject may be found [[?GAMMA FAQ]].</p>
 
+<p>Additional information on the impact of color space
+  on image encoding may be found in
+  [??Kasson]] and [[?Hill]].
+</p>
+
 <p>Background information about [=chromaticity=] and colour spaces
 may be found in [[?Luminance-Chromaticity]] and [[?COLOR FAQ]].</p>
 
@@ -8466,22 +8485,6 @@ see
 Bibliography</h2>
 
 <dl>
-
-
-<!-- Maintain a fragment named "G-ICC" to preserve incoming links to it -->
-<dt id="G-ICC">[ICC]</dt>
-
-<dd>The International Color Consortium.<br class="xhtml" />
- <a href=
-"http://www.color.org/"><code>http://www.color.org/</code></a></dd>
-
-
-<!-- Maintain a fragment named "G-KASSON" to preserve incoming links to it -->
-<dt id="G-KASSON">[KASSON]</dt>
-
-<dd>Kasson, J., and W. Plouffe, "An Analysis of Selected Computer
-Interchange Color Spaces", <i>ACM Transactions on Graphics</i>,
-vol. 11, no. 4 , pp. 373-405, 1992.</dd>
 
 
 <!-- Maintain a fragment named "G-PNG-1.0" to preserve incoming links to it -->

--- a/index.html
+++ b/index.html
@@ -170,6 +170,14 @@
         edition: "2",
         isbn: "0-201-18127-4"
       },
+      "ROELOFS": {
+        title: "PNG: The Definitive Guide",
+        author: "Roelofs, G.",
+        publisher: "O'Reilly &amp; Associates Inc",
+        isbn: "1-56592-542-4",
+        href: "http://www.libpng.org/pub/png/pngbook.html",
+        date: "1999-06-11"
+      }
       "SMPTE 170M": {
         title: "Television — Composite Analog Video Signal — NTSC for Studio Applications",
         publisher: "Society of Motion Picture and Television Engineers",
@@ -8377,6 +8385,7 @@ inflate, and an optimized implementation of the CRC algorithm are
 available from the zlib web site,
 <a href=
 "http://www.zlib.org/"><code>http://www.zlib.org/</code></a>.</p>
+
 </section>
 
 <!-- Maintain a fragment named "E-Sample-implementation" to preserve incoming links to it -->
@@ -8391,7 +8400,7 @@ Sample viewer and encoder applications of libpng are available at
 <a href=
 "http://www.libpng.org/pub/png/book/sources.html"><code>http://www.libpng.org/pub/png/book/sources.html</code></a>
 and are described in detail in <i>PNG: The Definitive Guide</i>
-<a href="#G-ROELOFS">[ROELOFS]</a>. Test images can also be
+[[?ROELOFS]]. Test images can also be
 accessed from the PNG web site.</p>
 </section>
 </section>
@@ -8458,12 +8467,6 @@ Bibliography</h2>
 
 <dl>
 
-<!-- Maintain a fragment named "G-HALL" to preserve incoming links to it -->
-<dt id="G-HALL">[HALL]</dt>
-
-<dd>Hall, Roy, <i>Illumination and Color in Computer Generated
-Imagery</i>. Springer-Verlag, New York, 1989. ISBN
-0-387-96774-5.</dd>
 
 <!-- Maintain a fragment named "G-ICC" to preserve incoming links to it -->
 <dt id="G-ICC">[ICC]</dt>
@@ -8471,13 +8474,6 @@ Imagery</i>. Springer-Verlag, New York, 1989. ISBN
 <dd>The International Color Consortium.<br class="xhtml" />
  <a href=
 "http://www.color.org/"><code>http://www.color.org/</code></a></dd>
-
-<!-- Maintain a fragment named "G-ISO-3664" to preserve incoming links to it -->
-<dt id="G-ISO-3664">[ISO-3664]</dt>
-
-<dd>ISO 3664:2000, <i>Viewing conditions &mdash; Graphic
-technology and photography</i>.</dd>
-
 
 
 <!-- Maintain a fragment named "G-KASSON" to preserve incoming links to it -->
@@ -8487,25 +8483,6 @@ technology and photography</i>.</dd>
 Interchange Color Spaces", <i>ACM Transactions on Graphics</i>,
 vol. 11, no. 4 , pp. 373-405, 1992.</dd>
 
-<!-- Maintain a fragment named "G-LILLEY" to preserve incoming links to it -->
-<dt id="G-LILLEY">[LILLEY]</dt>
-
-<dd>Lilley, C., F. Lin, W.T. Hewitt, and T.L.J. Howard, <i>Colour
-in Computer Graphics</i>. CVCP, Sheffield, 1993. ISBN
-1-85889-022-5.<br class="xhtml" />
-<!-- Also available from<br class="xhtml" />
- <a href=
-"http://www.man.ac.uk/MVC/training/gravigs/colour/"><code>http://www.man.ac.uk/MVC/training/gravigs/colour/</code></a>
---></dd>
-
-<!-- Maintain a fragment named "G-ROELOFS" to preserve incoming links to it -->
-<dt id="G-ROELOFS">[ROELOFS]</dt>
-
-<dd>Roelofs, G., <i>PNG: The Definitive Guide</i>, O'Reilly &amp;
-Associates Inc, Sebastopol, CA, 1999. ISBN 1-56592-542-4.
-See also <a href="http://www.libpng.org/pub/png/pngbook.html">
-<code>http://www.libpng.org/pub/png/pngbook.html</code>
-</a></dd>
 
 <!-- Maintain a fragment named "G-PNG-1.0" to preserve incoming links to it -->
 <dt id="G-PNG-1.0">[PNG-1.0]</dt>
@@ -8544,47 +8521,9 @@ Available  from:<br class="xhtml" />
 <a href=
 "https://w3c.github.io/PNG-spec/extensions/Overview.html"><code>https://w3c.github.io/PNG-spec/extensions/Overview.html</code></a></dd>
 
-
-<!-- Maintain a fragment named "G-POYNTON" to preserve incoming links to it -->
-<dt id="G-POYNTON">[POYNTON]</dt>
-
-<dd>Poynton, Charles A., <i>A Technical Introduction to Digital
-Video</i>. John Wiley and Sons, Inc., New York, 1996. ISBN
-0-471-12253-X.</dd>
-
-<!-- Maintain a fragment named "G-STONE" to preserve incoming links to it -->
-<dt id="G-STONE">[STONE]</dt>
-
-<dd>Stone, M.C., W.B. Cowan, and J.C. Beatty, "Color gamut
-mapping and the printing of digital images", <i>ACM Transactions on
-Graphics</i>, vol. 7, no. 3, pp. 249-292, 1988.</dd>
-
-<!-- Maintain a fragment named "G-TIFF-6.0" to preserve incoming links to it -->
-<dt id="G-TIFF-6.0">[TIFF 6.0]</dt>
-
-<dd>TIFF<sup>TM</sup> Revision 6.0, Aldus Corporation, June
-1992.</dd>
-
-<!-- Maintain a fragment named "G-TRAVIS" to preserve incoming links to it -->
-<dt id="G-TRAVIS">[TRAVIS]</dt>
-
-<dd>Travis, David, <i>Effective Color Displays &mdash; Theory and
-Practice</i>. Academic Press, London, 1991. ISBN
-0-12-697690-2.</dd>
-
-<!-- Maintain a fragment named "G-ZL" to preserve incoming links to it -->
-<dt id="G-ZL">[ZL]</dt>
-
-<dd>J. Ziv and A. Lempel, "A Universal Algorithm for Sequential
-Data Compression", <i>IEEE Transactions on Information
-Theory</i>, vol. IT-23, no. 3, pp. 337 - 343, 1977.</dd>
 </dl>
 
-<p>Additional documentation and portable C code for deflate,
-inflate, and an optimized implementation of the CRC algorithm are
-available from the zlib web site,
-<a href=
-"http://www.zlib.org/"><code>http://www.zlib.org/</code></a>.</p>
+
 </section>
 
 <script type="application/javascript" src="https://www.w3.org/scripts/TR/fixup.js"></script></body>

--- a/index.html
+++ b/index.html
@@ -131,6 +131,11 @@
         date: "2002-03-29",
         publisher: "ITU"
       },
+      "Luminance-Chromaticity": {
+        title: "Luminance and Chromaticity",
+        href: "https://colorusage.arc.nasa.gov/lum_and_chrom.php",
+        publisher: "Color Usage Research Lab, NASA Ames Research Center"
+      }
       "Paeth": {
         author: "Paeth, A.W",
         title: "Image File Compression Made Easy, in Graphics Gems II, pp. 93-100",
@@ -8198,7 +8203,9 @@ references <a href="#G-GAMMA-TUTORIAL"><span class=
 (especially chapter 6).</p>
 
 <p>Background information about [=chromaticity=] and colour spaces
-may be found in references <a href="#G-COLOUR-TUTORIAL"><span
+may be found in references [[?Luminance-Chromaticity]]
+
+<a href="#G-COLOUR-TUTORIAL"><span
 class="bibref">[COLOUR-TUTORIAL]</span></a>, <a href=
 "#G-COLOUR-FAQ"><span class="bibref">[COLOUR-FAQ]</span></a>, <a
 href="#G-HALL"><span class="bibref">[HALL]</span></a>, <a href=


### PR DESCRIPTION
Trim unused references
Trim non-normative references to out of print books (including my own :) )
Remove hard-coded bibliography section (replaced by ReSpec Informative References)

See https://github.com/w3c/PNG-spec/issues/82