### PR TITLE
Add missing comma in ReSpec config

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
         isbn: "1-56592-542-4",
         href: "http://www.libpng.org/pub/png/pngbook.html",
         date: "1999-06-11"
-      }
+      },
       "SMPTE 170M": {
         title: "Television — Composite Analog Video Signal — NTSC for Studio Applications",
         publisher: "Society of Motion Picture and Television Engineers",


### PR DESCRIPTION
The missing comma makes the script syntactically invalid and prevents spec generation by ReSpec.

Missing comma was introduced by recent local biblio changes.