### PR TITLE
Correct malformed markup, fix #145

### DIFF
--- a/index.html
+++ b/index.html
@@ -4996,7 +4996,7 @@ but each shall have a different palette name.</p>
     may appear anywhere between the <span class="chunk">IHDR</span>
     and <span class="chunk">IEND<span class="chunk"> chunks
     except between <span class="chunk">IDAT</span> chunks.
-    The <span class="chunk">eXIf</ chunk size is constrained
+    The <span class="chunk">eXIf</span> chunk size is constrained
     only by the maximum of 2<sup>31</sup>-1 bytes
     imposed by the PNG specification.
     Only one <span class="chunk">eXIf</span> chunk is allowed in a PNG datastream.</p>


### PR DESCRIPTION
A closing `</span>` was actually `</`