### PR TITLE
Add missing closing </section> tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -4300,6 +4300,7 @@ function defined at [[ITU-R BT.709]]:
 </aside>
 
 </section>
+</section>
 
 <!-- Maintain a fragment named "11textinfo" to preserve incoming links to it -->
 <section id="11textinfo">


### PR DESCRIPTION
The cICP chunk is missing a closing </section> tag.
As a result, the table of contents and section numbers are off.
For example, what would be section 12, PNG Encoders is instead 11.4.
This is under section 11, Chunk specifications.
Clearly, encoding is not part of the chunk spec.

This commit restores the missing </section> tag.