### PR TITLE
Fix informative ref to Kasson

### DIFF
--- a/index.html
+++ b/index.html
@@ -8323,7 +8323,7 @@ desired display output.</p>
 
 <p>Additional information on the impact of color space
   on image encoding may be found in
-  [??Kasson]] and [[?Hill]].
+  [?Kasson]] and [[?Hill]].
 </p>
 
 <p>Background information about [=chromaticity=] and colour spaces


### PR DESCRIPTION
The reference incorrectly was `[[??Kasson]]`, should be `[[?Kasson]]`