### PR TITLE
Fix autogenerated references section

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
       },
       "Hill": {
         title: "Comparative analysis of the quantization of color spaces on the basis of the CIELAB color-difference formula",
-        authors: "Hill, B.; Roger, Th., Vorhagen, F.W.",
+        author: "Hill, B.; Roger, Th., Vorhagen, F.W.",
         journal: "ACM Transactions on Graphics, Volume 16, Issue 2, pp. 109–154",
         date: "1997-04",
         href: "https://dl.acm.org/doi/10.1145/248210.248212"
@@ -152,7 +152,7 @@
       },
       "Kasson": {
         title: "An Analysis of Selected Computer Interchange Color Spaces",
-        authors: "Kasson, J., and W. Plouffe",
+        author: "Kasson, J., and W. Plouffe",
         journal: "ACM Transactions on Graphics, vol. 11, no. 4, pp. 373-405",
         date: "1992",
         href: "https://dl.acm.org/doi/abs/10.1145/146443.146479"


### PR DESCRIPTION
The localBiblio looks for an "author" field. But the Kasson and Hill
localBiblio had "authors" (plural). This prevented the references
section from being generated. It also did not issue a ReSpec error or
warning.

This commit renames those fields to "author" and restores the
autogenerated references section.

Closes #160 