### PR TITLE
Add missing chunk ordering diagrams (APNG), fix #143

### DIFF
--- a/figures/lattice-diagram-apng-static-first-with-plte.svg
+++ b/figures/lattice-diagram-apng-static-first-with-plte.svg
@@ -1,0 +1,211 @@
+<?xml version="1.0"?>
+<svg viewBox="0 0 825 550" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<style>
+    @font-face {
+        font-family: OS_Cond_Med;
+        src: url(./fonts/OS_Cond_Med.woff2);
+    }
+    rect {
+        stroke:#777;
+        fill:white;
+        }
+    text {
+        font-family: OS_Cond_Med;
+        font-size:18px;
+        text-anchor:start
+        }
+    line {
+        stroke:#777;
+        stroke-width:1
+        }
+</style>
+
+<!-- <rect width="100%" height="100%" style="fill: #F06" /> -->
+
+<g transform="translate(350,10)">
+<rect width="60" height="40" />
+<text x="5" y="25">IHDR</text>
+<text x="45" y="12" style="font-size:8pt">1</text>
+</g>
+
+<line x1="353" y1="50" x2="35" y2="120"/>
+<line x1="357" y1="50" x2="90" y2="120"/>
+<line x1="361" y1="50" x2="145" y2="120"/>
+<line x1="365" y1="50" x2="200" y2="120"/>
+<line x1="369" y1="50" x2="255" y2="120"/>
+<line x1="373" y1="50" x2="310" y2="120"/>
+<line x1="377" y1="50" x2="365" y2="120"/>
+
+<line x1="381" y1="50" x2="420" y2="120"/>
+<line x1="385" y1="50" x2="475" y2="120"/>
+<line x1="389" y1="50" x2="570" y2="120"/>
+<line x1="393" y1="50" x2="680" y2="120"/>
+<line x1="397" y1="50" x2="735" y2="120"/>
+<line x1="401" y1="50" x2="790" y2="120"/>
+
+
+<g transform="translate(0,120)">
+
+
+<g transform="translate(10,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">tIME</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(65,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">zTXt</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(120,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">tEXt</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(175,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">iTXt</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(230,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">pHYs</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(285,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">sPLT</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(340,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">eXIf</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(395,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">acTL</text>
+<text x="40" y="12" style="font-size:8pt">1</text>
+</g>
+<g transform="translate(450,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">fcTL</text>
+<text x="40" y="12" style="font-size:8pt">1</text>
+</g>
+
+<g transform="translate(125,0)">
+<g transform="translate(380,0)">
+<rect width="140" height="40" />
+<text x="5" y="25">(iCCP | cICP | sRGB)</text>
+<text x="130" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(525,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">sBIT</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(580,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">gAMA</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(635,0)">
+<rect width="55" height="40" />
+<text x="5" y="25">cHRM</text>
+<text x="45" y="12" style="font-size:8pt">?</text>
+</g>
+</g>
+
+</g>
+
+<line x1="659" y1="200" x2="570" y2="160"/>
+<line x1="663" y1="200" x2="680" y2="160"/>
+<line x1="667" y1="200" x2="735" y2="160"/>
+<line x1="671" y1="200" x2="790" y2="160"/>
+
+<g transform="translate(640,200)">
+<rect width="50" height="40" />
+<text x="5" y="25">PLTE</text>
+<text x="40" y="12" style="font-size:8pt">1</text>
+</g>
+
+<line x1="661" y1="240" x2="610" y2="280"/>
+<line x1="665" y1="240" x2="665" y2="280"/>
+<line x1="669" y1="240" x2="720" y2="280"/>
+
+<g transform="translate(60,280)">
+
+<g transform="translate(525,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">tRNS</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+<g transform="translate(580,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">hIST</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+<g transform="translate(635,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">bKGD</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+</g>
+
+<line x1="535" y1="360" x2="310" y2="160"/>
+<line x1="539" y1="360" x2="365" y2="160"/>
+<line x1="543" y1="360" x2="420" y2="160"/>
+<line x1="547" y1="360" x2="475" y2="160"/>
+
+<!--
+<line x1="661" y1="240" x2="610" y2="280"/>
+<line x1="665" y1="240" x2="665" y2="280"/>
+<line x1="669" y1="240" x2="720" y2="280"/> -->
+
+<line x1="551" y1="360" x2="610" y2="320"/>
+<line x1="555" y1="360" x2="665" y2="320"/>
+<line x1="559" y1="360" x2="720" y2="320"/>
+
+<g transform="translate(520,360)">
+<rect width="55" height="40" />
+<text x="5" y="25">IDAT</text>
+<text x="45" y="12" style="font-size:8pt">+</text>
+</g>
+
+<g transform="translate(420,430)">
+<rect width="60" height="40" />
+<text x="5" y="25">fdAT</text>
+<text x="45" y="12" style="font-size:8pt">+</text>
+</g>
+
+<g transform="translate(485,430)">
+<rect width="60" height="40" />
+<text x="5" y="25">fcTL</text>
+<text x="45" y="12" style="font-size:8pt">+</text>
+</g>
+
+
+<line x1="35" y1="160" x2="344" y2="500"/>
+<line x1="90" y1="160" x2="352" y2="500"/>
+<line x1="145" y1="160" x2="360" y2="500"/>
+<line x1="200" y1="160" x2="368" y2="500"/>
+<line x1="255" y1="160" x2="376" y2="500"/>
+
+<line x1="450" y1="430" x2="543" y2="400"/>
+<line x1="515" y1="430" x2="547" y2="400"/>
+
+<line x1="450" y1="470" x2="382" y2="500"/>
+<line x1="515" y1="470" x2="388" y2="500"/>
+
+<g transform="translate(340,500)">
+<rect width="60" height="40" />
+<text x="5" y="25">IEND</text>
+<text x="45" y="12" style="font-size:8pt">1</text>
+</g>
+
+
+</svg>
+

--- a/figures/lattice-diagram-apng-static-first-without-plte.svg
+++ b/figures/lattice-diagram-apng-static-first-without-plte.svg
@@ -1,0 +1,183 @@
+<?xml version="1.0" ?>
+<svg viewBox="0 0 985 535" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<style>
+    @font-face {
+        font-family: OS_Cond_Med;
+        src: url(./fonts/OS_Cond_Med.woff2);
+    }
+    rect {
+        stroke:#777;
+        fill:white;
+        }
+    text {
+        font-family: OS_Cond_Med;
+        font-size:18px;
+        text-anchor:start
+        }
+    line {
+        stroke:#777;
+        stroke-width:1
+        }
+</style>
+
+
+<g transform="translate(400,10)">
+<rect width="80" height="40" />
+<text x="15" y="25">IHDR</text>
+<text x="55" y="12" style="font-size:8pt">1</text>
+</g>
+
+<line x1="403" y1="50" x2="35" y2="120"/>
+<line x1="409" y1="50" x2="95" y2="120"/>
+<line x1="415" y1="50" x2="155" y2="120"/>
+<line x1="421" y1="50" x2="215" y2="120"/>
+<line x1="427" y1="50" x2="275" y2="120"/>
+<line x1="433" y1="50" x2="335" y2="120"/>
+<line x1="439" y1="50" x2="425" y2="120"/>
+<line x1="445" y1="50" x2="515" y2="120"/>
+<line x1="451" y1="50" x2="575" y2="120"/>
+<line x1="457" y1="50" x2="635" y2="120"/>
+<line x1="463" y1="50" x2="695" y2="120"/>
+<line x1="465" y1="50" x2="755" y2="120"/>
+<line x1="467" y1="50" x2="815" y2="120"/>
+<line x1="469" y1="50" x2="875" y2="120"/>
+<line x1="469" y1="50" x2="935" y2="120"/>
+
+<g transform="translate(0,120)">
+
+
+<g transform="translate(10,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">tIME</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(70,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">zTXt</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(130,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">tEXt</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(190,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">iTXt</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(249,0)">
+<rect width="48" height="40" />
+<text x="5" y="25">pHYs</text>
+<text x="38" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(307,0)">
+<rect width="47" height="40" />
+<text x="5" y="25">sPLT</text>
+<text x="37" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(363,0)">
+<rect width="130" height="40" />
+<text x="2" y="25">(iCCP | cICP | sRGB)</text>
+<text x="120" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(502,0)">
+<rect width="49" height="40" />
+<text x="5" y="25">sBIT</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(560,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">gAMA</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(620,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">cHRM</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+<g transform="translate(680,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">tRNS</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+<g transform="translate(740,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">bKGD</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+<g transform="translate(800,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">eXIf</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+<g transform="translate(860,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">acTL</text>
+<text x="40" y="12" style="font-size:8pt">1</text>
+</g>
+
+<g transform="translate(920,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">fcTL</text>
+<text x="40" y="12" style="font-size:8pt">1</text>
+</g>
+
+
+</g>
+
+
+<line x1="275" y1="160" x2="524" y2="300"/>
+<line x1="335" y1="160" x2="532" y2="300"/>
+<line x1="425" y1="160" x2="540" y2="300"/>
+<line x1="515" y1="160" x2="548" y2="300"/>
+<line x1="575" y1="160" x2="556" y2="300"/>
+<line x1="635" y1="160" x2="564" y2="300"/>
+<line x1="695" y1="160" x2="572" y2="300"/>
+<line x1="755" y1="160" x2="580" y2="300"/>
+<line x1="815" y1="160" x2="580" y2="300"/>
+<line x1="875" y1="160" x2="580" y2="300"/>
+<line x1="935" y1="160" x2="580" y2="300"/>
+
+
+<g transform="translate(520,300)">
+<rect width="80" height="40" />
+<text x="20" y="25">IDAT</text>
+<text x="60" y="12" style="font-size:8pt">+</text>
+</g>
+
+<line x1="35" y1="160" x2="344" y2="480"/>
+<line x1="95" y1="160" x2="352" y2="480"/>
+<line x1="155" y1="160" x2="360" y2="480"/>
+<line x1="215" y1="160" x2="368" y2="480"/>
+
+<g transform="translate(495,390)">
+<rect width="50" height="40" />
+<text x="5" y="25">fdAT</text>
+<text x="40" y="12" style="font-size:8pt">+</text>
+</g>
+<g transform="translate(595,390)">
+<rect width="50" height="40" />
+<text x="5" y="25">fcTL</text>
+<text x="40" y="12" style="font-size:8pt">+</text>
+</g>
+
+<line x1="555" y1="340" x2="520" y2="390"/>
+<line x1="565" y1="340" x2="620" y2="390"/>
+
+<g transform="translate(340,480)">
+<rect width="60" height="40" />
+<text x="5" y="25">IEND</text>
+<text x="45" y="12" style="font-size:8pt">1</text>
+</g>
+
+<line x1="520" y1="430" x2="380" y2="480"/>
+<line x1="620" y1="430" x2="380" y2="480"/>
+
+
+</svg>
+

--- a/figures/lattice-diagram-apng-static-notfirst-with-plte.svg
+++ b/figures/lattice-diagram-apng-static-notfirst-with-plte.svg
@@ -1,0 +1,206 @@
+<?xml version="1.0"?>
+<svg viewBox="0 0 825 550" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<style>
+    @font-face {
+        font-family: OS_Cond_Med;
+        src: url(./fonts/OS_Cond_Med.woff2);
+    }
+    rect {
+        stroke:#777;
+        fill:white;
+        }
+    text {
+        font-family: OS_Cond_Med;
+        font-size:18px;
+        text-anchor:start
+        }
+    line {
+        stroke:#777;
+        stroke-width:1
+        }
+</style>
+
+<!-- <rect width="100%" height="100%" style="fill: #F06" /> -->
+
+<g transform="translate(350,10)">
+<rect width="60" height="40" />
+<text x="5" y="25">IHDR</text>
+<text x="45" y="12" style="font-size:8pt">1</text>
+</g>
+
+<line x1="353" y1="50" x2="35" y2="120"/>
+<line x1="357" y1="50" x2="90" y2="120"/>
+<line x1="361" y1="50" x2="145" y2="120"/>
+<line x1="365" y1="50" x2="200" y2="120"/>
+<line x1="369" y1="50" x2="255" y2="120"/>
+<line x1="373" y1="50" x2="310" y2="120"/>
+<line x1="377" y1="50" x2="365" y2="120"/>
+
+<line x1="381" y1="50" x2="420" y2="120"/>
+<!-- <line x1="385" y1="50" x2="475" y2="120"/> -->
+<line x1="389" y1="50" x2="570" y2="120"/>
+<line x1="393" y1="50" x2="680" y2="120"/>
+<line x1="397" y1="50" x2="735" y2="120"/>
+<line x1="401" y1="50" x2="790" y2="120"/>
+
+
+<g transform="translate(0,120)">
+
+
+<g transform="translate(10,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">tIME</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(65,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">zTXt</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(120,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">tEXt</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(175,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">iTXt</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(230,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">pHYs</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(285,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">sPLT</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(340,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">eXIf</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(395,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">acTL</text>
+<text x="40" y="12" style="font-size:8pt">1</text>
+</g>
+<!-- <g transform="translate(450,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">fcTL</text>
+<text x="40" y="12" style="font-size:8pt">1</text>
+</g> -->
+
+<g transform="translate(125,0)">
+<g transform="translate(380,0)">
+<rect width="140" height="40" />
+<text x="5" y="25">(iCCP | cICP | sRGB)</text>
+<text x="130" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(525,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">sBIT</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(580,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">gAMA</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(635,0)">
+<rect width="55" height="40" />
+<text x="5" y="25">cHRM</text>
+<text x="45" y="12" style="font-size:8pt">?</text>
+</g>
+</g>
+
+</g>
+
+<line x1="659" y1="200" x2="570" y2="160"/>
+<line x1="663" y1="200" x2="680" y2="160"/>
+<line x1="667" y1="200" x2="735" y2="160"/>
+<line x1="671" y1="200" x2="790" y2="160"/>
+
+<g transform="translate(640,200)">
+<rect width="50" height="40" />
+<text x="5" y="25">PLTE</text>
+<text x="40" y="12" style="font-size:8pt">1</text>
+</g>
+
+<line x1="661" y1="240" x2="610" y2="280"/>
+<line x1="665" y1="240" x2="665" y2="280"/>
+<line x1="669" y1="240" x2="720" y2="280"/>
+
+<g transform="translate(60,280)">
+
+<g transform="translate(525,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">tRNS</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+<g transform="translate(580,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">hIST</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+<g transform="translate(635,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">bKGD</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+</g>
+
+<line x1="535" y1="360" x2="310" y2="160"/>
+<line x1="539" y1="360" x2="365" y2="160"/>
+<line x1="543" y1="360" x2="420" y2="160"/>
+<!-- <line x1="547" y1="360" x2="475" y2="160"/> -->
+
+<line x1="551" y1="360" x2="610" y2="320"/>
+<line x1="555" y1="360" x2="665" y2="320"/>
+<line x1="559" y1="360" x2="720" y2="320"/>
+
+<g transform="translate(520,360)">
+<rect width="55" height="40" />
+<text x="5" y="25">IDAT</text>
+<text x="45" y="12" style="font-size:8pt">+</text>
+</g>
+
+<g transform="translate(420,430)">
+<rect width="60" height="40" />
+<text x="5" y="25">fdAT</text>
+<text x="45" y="12" style="font-size:8pt">+</text>
+</g>
+
+<g transform="translate(485,430)">
+<rect width="60" height="40" />
+<text x="5" y="25">fcTL</text>
+<text x="45" y="12" style="font-size:8pt">+</text>
+</g>
+
+
+<line x1="35" y1="160" x2="344" y2="500"/>
+<line x1="90" y1="160" x2="352" y2="500"/>
+<line x1="145" y1="160" x2="360" y2="500"/>
+<line x1="200" y1="160" x2="368" y2="500"/>
+<line x1="255" y1="160" x2="376" y2="500"/>
+
+<line x1="450" y1="430" x2="543" y2="400"/>
+<line x1="515" y1="430" x2="547" y2="400"/>
+
+<line x1="450" y1="470" x2="382" y2="500"/>
+<line x1="515" y1="470" x2="388" y2="500"/>
+
+<g transform="translate(340,500)">
+<rect width="60" height="40" />
+<text x="5" y="25">IEND</text>
+<text x="45" y="12" style="font-size:8pt">1</text>
+</g>
+
+
+</svg>
+

--- a/figures/lattice-diagram-apng-static-notfirst-without-plte.svg
+++ b/figures/lattice-diagram-apng-static-notfirst-without-plte.svg
@@ -1,0 +1,182 @@
+<?xml version="1.0" ?>
+<svg viewBox="0 0 925 535" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<style>
+    @font-face {
+        font-family: OS_Cond_Med;
+        src: url(./fonts/OS_Cond_Med.woff2);
+    }
+    rect {
+        stroke:#777;
+        fill:white;
+        }
+    text {
+        font-family: OS_Cond_Med;
+        font-size:18px;
+        text-anchor:start
+        }
+    line {
+        stroke:#777;
+        stroke-width:1
+        }
+</style>
+
+<g transform="translate(400,10)">
+<rect width="80" height="40" />
+<text x="15" y="25">IHDR</text>
+<text x="55" y="12" style="font-size:8pt">1</text>
+</g>
+
+<line x1="403" y1="50" x2="35" y2="120"/>
+<line x1="409" y1="50" x2="95" y2="120"/>
+<line x1="415" y1="50" x2="155" y2="120"/>
+<line x1="421" y1="50" x2="215" y2="120"/>
+<line x1="427" y1="50" x2="275" y2="120"/>
+<line x1="433" y1="50" x2="335" y2="120"/>
+<line x1="439" y1="50" x2="425" y2="120"/>
+<line x1="445" y1="50" x2="515" y2="120"/>
+<line x1="451" y1="50" x2="575" y2="120"/>
+<line x1="457" y1="50" x2="635" y2="120"/>
+<line x1="463" y1="50" x2="695" y2="120"/>
+<line x1="465" y1="50" x2="755" y2="120"/>
+<line x1="467" y1="50" x2="815" y2="120"/>
+<line x1="469" y1="50" x2="875" y2="120"/>
+<!-- <line x1="469" y1="50" x2="935" y2="120"/> -->
+
+<g transform="translate(0,120)">
+
+
+<g transform="translate(10,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">tIME</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(70,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">zTXt</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(130,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">tEXt</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(190,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">iTXt</text>
+<text x="40" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(249,0)">
+<rect width="48" height="40" />
+<text x="5" y="25">pHYs</text>
+<text x="38" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(307,0)">
+<rect width="47" height="40" />
+<text x="5" y="25">sPLT</text>
+<text x="37" y="12" style="font-size:8pt">*</text>
+</g>
+<g transform="translate(363,0)">
+<rect width="130" height="40" />
+<text x="2" y="25">(iCCP | cICP | sRGB)</text>
+<text x="120" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(502,0)">
+<rect width="49" height="40" />
+<text x="5" y="25">sBIT</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(560,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">gAMA</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+<g transform="translate(620,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">cHRM</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+<g transform="translate(680,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">tRNS</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+<g transform="translate(740,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">bKGD</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+<g transform="translate(800,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">eXIf</text>
+<text x="40" y="12" style="font-size:8pt">?</text>
+</g>
+
+<g transform="translate(860,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">acTL</text>
+<text x="40" y="12" style="font-size:8pt">1</text>
+</g>
+
+<!-- <g transform="translate(920,0)">
+<rect width="50" height="40" />
+<text x="5" y="25">fcTL</text>
+<text x="40" y="12" style="font-size:8pt">1</text>
+</g> -->
+
+
+</g>
+
+
+<line x1="275" y1="160" x2="524" y2="300"/>
+<line x1="335" y1="160" x2="532" y2="300"/>
+<line x1="425" y1="160" x2="540" y2="300"/>
+<line x1="515" y1="160" x2="548" y2="300"/>
+<line x1="575" y1="160" x2="556" y2="300"/>
+<line x1="635" y1="160" x2="564" y2="300"/>
+<line x1="695" y1="160" x2="572" y2="300"/>
+<line x1="755" y1="160" x2="580" y2="300"/>
+<line x1="815" y1="160" x2="580" y2="300"/>
+<line x1="875" y1="160" x2="580" y2="300"/>
+<!-- <line x1="935" y1="160" x2="580" y2="300"/> -->
+
+
+<g transform="translate(520,300)">
+<rect width="80" height="40" />
+<text x="20" y="25">IDAT</text>
+<text x="60" y="12" style="font-size:8pt">+</text>
+</g>
+
+<line x1="35" y1="160" x2="344" y2="480"/>
+<line x1="95" y1="160" x2="352" y2="480"/>
+<line x1="155" y1="160" x2="360" y2="480"/>
+<line x1="215" y1="160" x2="368" y2="480"/>
+
+<g transform="translate(495,390)">
+<rect width="50" height="40" />
+<text x="5" y="25">fdAT</text>
+<text x="40" y="12" style="font-size:8pt">+</text>
+</g>
+<g transform="translate(595,390)">
+<rect width="50" height="40" />
+<text x="5" y="25">fcTL</text>
+<text x="40" y="12" style="font-size:8pt">+</text>
+</g>
+
+<line x1="555" y1="340" x2="520" y2="390"/>
+<line x1="565" y1="340" x2="620" y2="390"/>
+
+<g transform="translate(340,480)">
+<rect width="60" height="40" />
+<text x="5" y="25">IEND</text>
+<text x="45" y="12" style="font-size:8pt">1</text>
+</g>
+
+<line x1="520" y1="430" x2="380" y2="480"/>
+<line x1="620" y1="430" x2="380" y2="480"/>
+
+
+</svg>
+

--- a/figures/lattice-diagram-with-plte.svg
+++ b/figures/lattice-diagram-with-plte.svg
@@ -20,7 +20,7 @@
         }
 </style>
 
-<rect width="100%" height="100%" fill="#F06" />
+<!-- <rect width="100%" height="100%" fill="#F06" /> -->
 
 <g transform="translate(300,10)">
 <rect width="60" height="40" />
@@ -87,17 +87,17 @@
 <text x="5" y="25">(iCCP | cICP | sRGB)</text>
 <text x="130" y="12" style="font-size:8pt">?</text>
 </g>
-<g transform="translate(540,0)">
+<g transform="translate(530,0)">
 <rect width="50" height="40" />
 <text x="5" y="25">sBIT</text>
 <text x="40" y="12" style="font-size:8pt">?</text>
 </g>
-<g transform="translate(600,0)">
+<g transform="translate(590,0)">
 <rect width="50" height="40" />
 <text x="5" y="25">gAMA</text>
 <text x="40" y="12" style="font-size:8pt">?</text>
 </g>
-<g transform="translate(660,0)">
+<g transform="translate(650,0)">
 <rect width="55" height="40" />
 <text x="5" y="25">cHRM</text>
 <text x="45" y="12" style="font-size:8pt">?</text>
@@ -106,20 +106,20 @@
 
 </g>
 
-<line x1="590" y1="200" x2="535" y2="160"/>
-<line x1="600" y1="200" x2="625" y2="160"/>
-<line x1="610" y1="200" x2="685" y2="160"/>
-<line x1="620" y1="200" x2="745" y2="160"/>
+<line x1="605" y1="200" x2="535" y2="160"/>
+<line x1="611" y1="200" x2="615" y2="160"/>
+<line x1="617" y1="200" x2="675" y2="160"/>
+<line x1="623" y1="200" x2="735" y2="160"/>
 
-<g transform="translate(580,200)">
+<g transform="translate(600,200)">
 <rect width="50" height="40" />
 <text x="5" y="25">PLTE</text>
 <text x="40" y="12" style="font-size:8pt">1</text>
 </g>
 
-<line x1="590" y1="240" x2="525" y2="280"/>
-<line x1="600" y1="240" x2="605" y2="280"/>
-<line x1="610" y1="240" x2="685" y2="280"/>
+<line x1="610" y1="240" x2="525" y2="280"/>
+<line x1="620" y1="240" x2="605" y2="280"/>
+<line x1="630" y1="240" x2="685" y2="280"/>
 
 <g transform="translate(0,280)">
 

--- a/index.html
+++ b/index.html
@@ -2504,14 +2504,6 @@ type="image/svg+xml">
 class="chunk">PLTE</span></a></figcaption>
 </figure>
 
-<!--
-for animated images where the static image forms the first frame in
-<a href="#lattice-apng-static-with-plte"></a> and
-<a href="#lattice-apng-static-without-plte"></a>, and
-for animated images where the static image is not part of the animation in
-<a href="#lattice-apng-nostatic-with-plte"></a> and
-<a href="#lattice-apng-nostatic-without-plte"></a>. -->
-
 
 <figure id="lattice-apng-static-with-plte">
 <object id="figure52a" data="figures/lattice-diagram-apng-static-first-with-plte.svg" type="image/svg+xml">

--- a/index.html
+++ b/index.html
@@ -2229,9 +2229,16 @@ table to accelerate the computation. See <a href=
 
 <p>The constraints on the positioning of the individual chunks
 are listed in <a href="#table53">
-</a> and illustrated diagrammatically in <a href=
+</a> and illustrated diagrammatically
+for static images in <a href=
 "#lattice-diagram-with-plte"></a> and <a
-href="#lattice-diagram-without-plte"></a>.
+href="#lattice-diagram-without-plte"></a>,
+for animated images where the static image forms the first frame in
+<a href="#lattice-apng-static-with-plte"></a> and
+<a href="#lattice-apng-static-without-plte"></a>, and
+for animated images where the static image is not part of the animation in
+<a href="#lattice-apng-nostatic-with-plte"></a> and
+<a href="#lattice-apng-nostatic-without-plte"></a>.
 These lattice diagrams represent the constraints on positioning
 imposed by this specification. The lines in the diagrams
 define partial ordering relationships. Chunks higher up shall
@@ -2484,7 +2491,7 @@ symbols used in lattice diagrams</caption>
 <object id="figure52" data="figures/lattice-diagram-with-plte.svg" type="image/svg+xml">
 </object>
 <figcaption>Lattice diagram: Static PNG images with <a href="#11PLTE"><span class=
-"chunk">PLTE</span></a> in datastream</figcaption>
+"chunk">PLTE</span></a></figcaption>
 </figure>
 
 
@@ -2494,8 +2501,49 @@ symbols used in lattice diagrams</caption>
 type="image/svg+xml">
 </object>
 <figcaption>Lattice diagram: Static PNG images without <a href="#11PLTE"><span
-class="chunk">PLTE</span></a> in datastream</figcaption>
+class="chunk">PLTE</span></a></figcaption>
 </figure>
+
+<!--
+for animated images where the static image forms the first frame in
+<a href="#lattice-apng-static-with-plte"></a> and
+<a href="#lattice-apng-static-without-plte"></a>, and
+for animated images where the static image is not part of the animation in
+<a href="#lattice-apng-nostatic-with-plte"></a> and
+<a href="#lattice-apng-nostatic-without-plte"></a>. -->
+
+
+<figure id="lattice-apng-static-with-plte">
+<object id="figure52a" data="figures/lattice-diagram-apng-static-first-with-plte.svg" type="image/svg+xml">
+</object>
+<figcaption>Lattice diagram: Animated PNG images with <a href="#11PLTE"><span class=
+"chunk">PLTE</span></a>, static image forms the first frame</figcaption>
+</figure>
+
+
+<figure id="lattice-apng-static-without-plte">
+<object id="figure53a" data="figures/lattice-diagram-apng-static-first-without-plte.svg"
+type="image/svg+xml">
+</object>
+<figcaption>Lattice diagram: Animated PNG images without <a href="#11PLTE"><span
+class="chunk">PLTE</span></a>, static image forms the first frame</figcaption>
+</figure>
+
+<figure id="lattice-apng-nostatic-with-plte">
+  <object id="figure52b" data="figures/lattice-diagram-apng-static-notfirst-with-plte.svg" type="image/svg+xml">
+  </object>
+  <figcaption>Lattice diagram: Animated PNG images with <a href="#11PLTE"><span class=
+  "chunk">PLTE</span></a>, static image not part of animation</figcaption>
+  </figure>
+
+
+  <figure id="lattice-apng-nostatic-without-plte">
+  <object id="figure53b" data="figures/lattice-diagram-apng-static-notfirst-without-plte.svg"
+  type="image/svg+xml">
+  </object>
+  <figcaption>Lattice diagram: Animated PNG images without <a href="#11PLTE"><span
+  class="chunk">PLTE</span></a>, static image not part of animation</figcaption>
+  </figure>
 
 </section>
 


### PR DESCRIPTION
Adds four diagrams:

 -  APNG with PLTE, first frame is IDAT
 -  APNG with PLTE, first frame is not IDAT
 -  APNG with no PLTE, first frame is IDAT
 -   APNG with no PLTE, first frame is not IDAT

Fixes one other diagram which still showed a bounding box rectangle used during editing

Adds these diagrams to the spec.

The figure elements have sensible ids. The object elements have ids, which are at least unique, but I would also be fine with dropping the object ids.
