### PR TITLE
Recommend iTXt, fix #144

### DIFF
--- a/index.html
+++ b/index.html
@@ -2534,8 +2534,8 @@ class="chunk">PLTE</span></a> in datastream</figcaption>
     experimental use.</p>
 
     <p>A private chunk SHOULD NOT be defined merely to carry textual information
-    of interest to a human user. Instead <a href="#11tEXt"><span
-    class= "chunk">tEXt</span></a> chunk SHOULD BE used and corresponding
+    of interest to a human user. Instead <a href="#11iTXt"><span
+    class= "chunk">iTXt</span></a> chunk SHOULD BE used and corresponding
     keyword SHOULD BE used and a suitable keyword defined.</p>
 
     <p>Listing private chunks at [[PNG-EXTENSIONS]] reduces, but does not eliminate,


### PR DESCRIPTION
Recommend using UTF-8 `iTXt` rather than Latin-1 `tEXt` for new, textual information.