### PR TITLE
Add `cICP` and `eXIf` to ancillary info table, fix #168

### DIFF
--- a/index.html
+++ b/index.html
@@ -1610,6 +1610,20 @@ if no better option is available.</td>
 </tr>
 
 <tr>
+  <td class="Regular">Coding-independent code points</td>
+  <td class="Regular">Identifies the colour space by enumerating metadata
+    such as the transfer function and colour primaries.
+    Originally for SDR and HDR video, also used for
+    still and animated images.
+  </td>
+</tr>
+
+<tr>
+  <td class="Regular">EXIF information</td>
+  <td class="Regular">Exchangeable image file format metadata such as shutter speed, aperture, and orientation</td>
+</tr>
+
+<tr>
 <td class="Regular">Gamma and chromaticity</td>
 <td class="Regular">Gamma characteristic of the image with respect to the desired
 output intensity, and [=chromaticity=] characteristics of the RGB


### PR DESCRIPTION
Add descriptions of the type of information contained in `cICP` and `eXIf` chunks