### PR TITLE
Oor palette index, fix #96

### DIFF
--- a/index.html
+++ b/index.html
@@ -6517,6 +6517,13 @@ need not terminate.</p>
 warning to the user if appropriate, recover from the error, and
 continue processing normally.</p>
 
+<p>When decoding an indexed-color PNG, if out-of-range indexes are encountered,
+  decoders have historically varied in their handling of this error.
+  Displaying the pixel as opaque black is one common error recovery tactic,
+  although such behaviour is not required by this specification
+  and must not be relied on by encoders.
+</p>
+
 <p>Decoders that do not compute CRCs should interpret apparent
 syntax errors as indications of corruption (see also <a href="#13Error-checking"></a>).</p>
 

--- a/index.html
+++ b/index.html
@@ -1317,6 +1317,12 @@ colours.</p>
 so that the table entries with the maximum alpha value are
 grouped at the end. In this case the table can be encoded in a
 shortened form that does not include these entries.</p>
+
+<p>Encoders creating indexed-color PNG must not insert
+  index values greater than the actual length of the palette table;
+  to do so is an error, and decoders will vary in their handling of this error.
+</p>
+
 </section>
 
 <!-- Maintain a fragment named "4Concepts.RGBMerging" to preserve incoming links to it -->


### PR DESCRIPTION
Defines opaque black as one common error recovery method.
Decoders have varied, so encoders must not rely on this presentation.