### PR TITLE
Remove links from headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -2086,8 +2086,8 @@ rules</caption>
 
 <tr>
 <th colspan="3">Critical chunks<br />
- (shall appear in this order, except <a href="#11PLTE"><span
-class="chunk">PLTE</span></a> is optional)</th>
+ (shall appear in this order, except 
+PLTE is optional)</th>
 </tr>
 
 <tr>
@@ -3996,8 +3996,8 @@ the following values shall be used.</p>
 <caption>gAMA and cHRM values for sRGB</caption>
 
 <tr>
-<th colspan="2"><a href="#11gAMA"><span class=
-"chunk">gAMA</span></a> </th>
+<th colspan="2">
+gAMA</th>
 </tr>
 
 <tr>
@@ -4006,8 +4006,8 @@ the following values shall be used.</p>
 </tr>
 
 <tr>
-<th colspan="2"><a href="#11cHRM"><span class=
-"chunk">cHRM</span></a> </th>
+<th colspan="2">
+cHRM</th>
 </tr>
 
 <tr>


### PR DESCRIPTION
There are a few headers which include links in them. The default table header background is dark blue. And the default section link is brown. This brown text on top of dark blue background is difficult to read.

Further, headings shouldn't contain links, anyway.

This commit removes links from within headers.

Closes #187