### PR TITLE
Fix typo and leftover code

### DIFF
--- a/index.html
+++ b/index.html
@@ -2159,10 +2159,10 @@ and <a class="chunk" href="#11IDAT">IDAT</a> </td>
 <tr>
 <td><a class="chunk" href="#11iCCP">iCCP</a> </td>
 <td>No</td>
-<td">Before <a class="chunk" href="#11PLTE">PLTE</a>
+<td>Before <a class="chunk" href="#11PLTE">PLTE</a>
 and <a class="chunk" href="#11IDAT">IDAT</a>. If the
 <a class="chunk" href="#11iCCP">iCCP</a> chunk is
-present, the <a class="chunk" href="#11sRGB"><span class=
+present, the <a class="chunk" href="#11sRGB">
 sRGB</a> chunk should not be present.</td>
 </tr>
 


### PR DESCRIPTION
There is a typo with <td"> that was causing problems. There is also code that was meant to be deleted ('<span class="' at the end of a line) which was left in place.

This commit fixes both of those mistakes.