### PR TITLE
Fix unterminated link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1538,7 +1538,7 @@ image.</td>
 
   <!-- <ol start="5"> --><ol>
   <li>Transparency information: <a class="chunk" href="#11tRNS">
-tRNS</a> (see <a href="#11transinfo"></a></li>
+tRNS</a> (see <a href="#11transinfo"></a>).</li>
 
   <li>Colour space information: <a class="chunk" href="#11cHRM">
 cHRM</a>, <a class="chunk" href="#11gAMA">
@@ -1546,12 +1546,12 @@ gAMA</a>, <a class="chunk" href="#11iCCP">
 iCCP</a>, <a class="chunk" href="#11sBIT">
 sBIT</a>, <a class="chunk" href="#11sRGB">
 sRGB</a>, <a class="chunk" href="#cICP-chunk">
-cICP</a> (see <a href="#11addnlcolinfo"></a></li>
+cICP</a> (see <a href="#11addnlcolinfo"></a>).</li>
 
   <li>Textual information: <a class="chunk" href="#11iTXt">
 iTXt</a>, <a class="chunk" href="#11tEXt">
 tEXt</a>, <a class="chunk" href="#11zTXt">
-zTXt</a> (see <a href="#11textinfo"></a).</li>
+zTXt</a> (see <a href="#11textinfo"></a>).</li>
 
   <li>Miscellaneous information: <a class="chunk" href="#11bKGD">
 bKGD</a>, <a class="chunk" href="#11hIST">


### PR DESCRIPTION
There is a link with "`</a`" instead of "`</a>`". This broken closing tag caused text behind it to be included in the link.

This commit fixes the closing tag.

Closes #202 