### PR TITLE
Fix broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -761,7 +761,7 @@ image it is the same as the <a>bit depth</a>.</dd>
 
   <dd>non-animated image
     corresponding to the <a>reference image</a>
-    encoded in the <a class="chunk" href="11IDAT">IDAT</a> chunk.
+    encoded in the <a class="chunk" href="#11IDAT">IDAT</a> chunk.
     All PNG and APNG images contain a static image,
     and non animation-capable displays (such as printers)
     will display this rather than the animation.
@@ -1534,7 +1534,7 @@ eXIf</a>
 tIME</a> (see <a href="#11timestampinfo"></a>).</li>
 
   <li>Animation information:
-    <a class="chunk" href="#actl-animation-control-chunk">acTL</a>,
+    <a class="chunk" href="#acTL-chunk">acTL</a>,
     <a class="chunk" href="#fcTL-chunk">fcTL</a>,
     <a class="chunk" href="#fdAT-chunk">fdAT</a>
     (see <a href="#animation-information"></a>).
@@ -1571,9 +1571,9 @@ tIME</a> (see <a href="#11timestampinfo"></a>).</li>
   describing the animation
   and providing additional frame data. </p>
 
-<p>To be recognized as an APNG, an <a class="chunk" href="#actl-animation-control-chunk">acTL</a> chunk
+<p>To be recognized as an APNG, an <a class="chunk" href="#acTL-chunk">acTL</a> chunk
   must appear in the stream before any <a class="chunk" href="#11IDAT">IDAT</a> chunks.
-  The <a class="chunk" href="#actl-animation-control-chunk">acTL</a> structure is
+  The <a class="chunk" href="#acTL-chunk">acTL</a> structure is
   <a href="#animation-information">described below</a>. </p>
 
 <p>Conceptually, at the beginning of each play
@@ -1644,7 +1644,7 @@ tIME</a> (see <a href="#11timestampinfo"></a>).</li>
 </tr>
 <tr>
   <td>(none)</td>
-  <td><a class="chunk" href="#actl-animation-control-chunk">acTL</a></td>
+  <td><a class="chunk" href="#acTL-chunk">acTL</a></td>
 </tr>
 <tr>
   <td>0</td>
@@ -1677,7 +1677,7 @@ tIME</a> (see <a href="#11timestampinfo"></a>).</li>
 </tr>
 <tr>
   <td>(none)</td>
-  <td><a class="chunk" href="#actl-animation-control-chunk">acTL</a></td>
+  <td><a class="chunk" href="#acTL-chunk">acTL</a></td>
 </tr>
 <tr>
   <td>(none)</td>
@@ -2098,7 +2098,7 @@ IDAT</a> chunks shall be consecutive</td>
 </tr>
 
 <tr>
-<td><a class="chunk" href="#actl-animation-control-chunk">acTL</a> </td>
+<td><a class="chunk" href="#acTL-chunk">acTL</a> </td>
 <td>No</td>
 <td>Before <a class="chunk" href="#11PLTE">PLTE</a>
 and <a class="chunk" href="#11IDAT">IDAT</a> </td>
@@ -4995,10 +4995,10 @@ the <a>image data</a> are changed.</p>
 </section>
 </section>
 
-<section>
+<section id="animation-information">
   <h2>Animation information</h2>
 
-  <section>
+  <section id="acTL-chunk">
     <h2><span class="chunk">acTL</span>
     Animation Control Chunk</h2>
 


### PR DESCRIPTION
The W3C Link Checker complains of broken links. There is indeed a broken link. But there are also links that only work after JavaScript has run. The Link Checker does not run JavaScript, so it complains about these links, too.

This commit fixes the broken links found by W3C's Link Checker.

Closes #190