### PR TITLE
Fix ReSpec error

### DIFF
--- a/index.html
+++ b/index.html
@@ -8377,12 +8377,8 @@ accessed from the PNG web site.</p>
 </section>
 </section>
 
-<section class="appendix informative">
-
-
 <!-- Maintain a fragment named "F-ChangeList" to preserve incoming links to it -->
-<a id="F-ChangeList"></a>
-
+<section id="F-ChageList" class="appendix informative">
 <h2 class="Annex">Changes</h2>
 
 <h3>Changes since the


### PR DESCRIPTION
There is an <a> element that doesn't link anyway. It is given an id to be a link destination. ReSpec does not understand the intent of this empty, no-destination anchor element. ReSpec errors on this strange situation.

This commit removes the erroring <a> tag and maintains the id on a more appropriate tag.