### PR TITLE
Updates after FPWD

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,12 +13,11 @@
     <script class="remove">
       var respecConfig = {
           group: "png",
-          specStatus: "FPWD",
-	  shortName: "PNG",
-    publishDate: "2022-10-25",
+          specStatus: "ED",
+	  shortName: "png-3",
 	  copyrightStart: "1996",
-	  previousPublishDate: "2003-11-10",
-	  previousMaturity: "REC",
+	  previousPublishDate: "2022-10-25",
+	  previousMaturity: "FPWD",
     github: "https://github.com/w3c/PNG-spec",
 	  edDraftURI: "https://w3c.github.io/PNG-spec",
 	  extraCSS: ["http://dev.w3.org/2009/dap/ReSpec.js/css/respec.css"],


### PR DESCRIPTION
The [First Public Working Draft](https://www.w3.org/TR/2022/WD-png-3-20221025/) is published today, so this PR:

- Updates shortname to png-3, like the FPWD
- Removes publication date, so it is always the date of last edit
- Updates previous publication date and status
-  Sets status back to Editors Draft