### PR TITLE
Cleanup tidy config

### DIFF
--- a/tidy.cfg
+++ b/tidy.cfg
@@ -22,6 +22,7 @@ indent-spaces: 2
 markup: yes
 tab-size: 2
 wrap: 132
+vertical-space: yes
 
 # Character encoding options
 char-encoding: utf8
@@ -30,4 +31,4 @@ newline: LF
 # Miscellaneous options
 tidy-mark: no
 
-vertical-space: yes
+


### PR DESCRIPTION
The vertical-space config option was not grouped with its other options. This commit puts it in its "Pretty print options" group.