### PR TITLE
Only error on new GitHub workflow issues

### DIFF
--- a/.github/workflows/formatting-checker.yaml
+++ b/.github/workflows/formatting-checker.yaml
@@ -33,4 +33,4 @@ jobs:
       run: tidy -f old-tidy-results -config tidy.cfg -e main/index.html || true
 
     - name: Diff HTML Tidy results
-      run: diff -u old-tidy-results new-tidy-results
+      run: diff -u old-tidy-results new-tidy-results | not grep -E "^\+"

--- a/.github/workflows/formatting-checker.yaml
+++ b/.github/workflows/formatting-checker.yaml
@@ -21,4 +21,13 @@ jobs:
       run: sudo apt install tidy
 
     - name: Run HTML Tidy
-      run: tidy -config tidy.cfg -e index.html
+      run: tidy -f new-tidy-results -config tidy.cfg -e index.html
+
+    - name: Checkout main
+      run: git checkout main
+
+    - name: Run HTML Tidy
+      run: tidy -f old-tidy-results -config tidy.cfg -e index.html
+
+    - name: Diff HTML Tidy results
+      run: diff -u old-tidy-results new-tidy-results | grep -E "^\+"

--- a/.github/workflows/formatting-checker.yaml
+++ b/.github/workflows/formatting-checker.yaml
@@ -17,19 +17,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Checkout main
+      uses: actions/checkout@v3
+      with:
+        ref: main
+        path: main
+
     - name: Install HTML Tidy
       run: sudo apt install tidy
 
     - name: Run HTML Tidy
       run: tidy -f new-tidy-results -config tidy.cfg -e index.html || true
 
-    - name: Checkout main
-      uses: actions/checkout@v3
-      with:
-        ref: main
-
     - name: Run HTML Tidy
-      run: tidy -f old-tidy-results -config tidy.cfg -e index.html || true
+      run: tidy -f old-tidy-results -config tidy.cfg -e main/index.html || true
 
     - name: Diff HTML Tidy results
       run: diff -u old-tidy-results new-tidy-results | grep -E "^\+"

--- a/.github/workflows/formatting-checker.yaml
+++ b/.github/workflows/formatting-checker.yaml
@@ -33,4 +33,4 @@ jobs:
       run: tidy -f old-tidy-results -config tidy.cfg -e main/index.html || true
 
     - name: Diff HTML Tidy results
-      run: diff -u old-tidy-results new-tidy-results | not grep -E "^\+"
+      run: diff -u old-tidy-results new-tidy-results | ! grep -E "^\+"

--- a/.github/workflows/formatting-checker.yaml
+++ b/.github/workflows/formatting-checker.yaml
@@ -24,7 +24,9 @@ jobs:
       run: tidy -f new-tidy-results -config tidy.cfg -e index.html || true
 
     - name: Checkout main
-      run: git checkout main
+      uses: actions/checkout@v3
+      with:
+        ref: main
 
     - name: Run HTML Tidy
       run: tidy -f old-tidy-results -config tidy.cfg -e index.html || true

--- a/.github/workflows/formatting-checker.yaml
+++ b/.github/workflows/formatting-checker.yaml
@@ -33,6 +33,4 @@ jobs:
       run: tidy -f old-tidy-results -config tidy.cfg -e main/index.html || true
 
     - name: Diff HTML Tidy results
-      run: diff -u old-tidy-results new-tidy-results | grep -E "^\+"
-      register: log_errors
-      failed_when: "log_errors.rc == 0"
+      run: diff -u old-tidy-results new-tidy-results | (! grep -E "^\+")

--- a/.github/workflows/formatting-checker.yaml
+++ b/.github/workflows/formatting-checker.yaml
@@ -33,4 +33,6 @@ jobs:
       run: tidy -f old-tidy-results -config tidy.cfg -e main/index.html || true
 
     - name: Diff HTML Tidy results
-      run: diff -u old-tidy-results new-tidy-results | ! grep -E "^\+"
+      run: diff -u old-tidy-results new-tidy-results | grep -E "^\+"
+      register: log_errors
+      failed_when: "log_errors.rc == 0"

--- a/.github/workflows/formatting-checker.yaml
+++ b/.github/workflows/formatting-checker.yaml
@@ -33,4 +33,4 @@ jobs:
       run: tidy -f old-tidy-results -config tidy.cfg -e main/index.html || true
 
     - name: Diff HTML Tidy results
-      run: diff -u old-tidy-results new-tidy-results | grep -E "^\+"
+      run: diff -u old-tidy-results new-tidy-results

--- a/.github/workflows/formatting-checker.yaml
+++ b/.github/workflows/formatting-checker.yaml
@@ -21,13 +21,13 @@ jobs:
       run: sudo apt install tidy
 
     - name: Run HTML Tidy
-      run: tidy -f new-tidy-results -config tidy.cfg -e index.html
+      run: tidy -f new-tidy-results -config tidy.cfg -e index.html || true
 
     - name: Checkout main
       run: git checkout main
 
     - name: Run HTML Tidy
-      run: tidy -f old-tidy-results -config tidy.cfg -e index.html
+      run: tidy -f old-tidy-results -config tidy.cfg -e index.html || true
 
     - name: Diff HTML Tidy results
       run: diff -u old-tidy-results new-tidy-results | grep -E "^\+"


### PR DESCRIPTION
Currently, the GitHub workflow (which runs on every pull request) will report errors if the existing files contain errors. This is unfortunate because people who create new pull requests will see an error when they did not cause it.

This commit will instead only error if the pull request introduces a new error.