### PR TITLE
Add mASt chunk

### DIFF
--- a/index.html
+++ b/index.html
@@ -1410,10 +1410,9 @@ with these exceptions:
       <section id="4Concepts.FormatTypes">
         <h2>Chunk types</h2>
 
-        <p>There are 24 chunk types defined in this International Standard. Chunk types are four-byte sequences chosen so that they
-        correspond to readable labels when interpreted in the ISO 646.IRV:1991 [[ISO646]] character set. The first four are termed
-        critical chunks, which shall be understood and correctly interpreted according to the provisions of this specification.
-        These are:</p>
+        <p>Chunk types are four-byte sequences chosen so that they correspond to readable labels when interpreted in the ISO
+        646.IRV:1991 [[ISO646]] character set. The first four are termed critical chunks, which shall be understood and correctly
+        interpreted according to the provisions of this specification. These are:</p>
         <!-- <ol start="1"> -->
 
         <ol>
@@ -1434,8 +1433,7 @@ with these exceptions:
           </li>
         </ol>
 
-        <p>The remaining 20 chunk types are termed ancillary chunk types, which encoders may generate and decoders may
-        interpret.</p>
+        <p>The remaining chunk types are termed ancillary chunk types, which encoders may generate and decoders may interpret.</p>
         <!-- <ol start="5"> -->
 
         <ol>

--- a/index.html
+++ b/index.html
@@ -4101,12 +4101,16 @@ with these exceptions:
           <p>For the Creation Time keyword, the date format defined in section&#160;5.2.14 of RFC 1123 is suggested, but not
           required [[rfc1123]].</p>
 
-          <p>In the <a class="chunk" href="#11tEXt">tEXt</a> and <a class="chunk" href="#11zTXt">zTXt</a> chunks, the text string
-          associated with a keyword is restricted to the Latin-1 character set plus the linefeed character. Text strings in
-          <a class="chunk" href="#11zTXt">zTXt</a> are compressed into <a>zlib</a> datastreams using <a>deflate</a> compression
-          (see <a href='#10CompressionOtherUses'></a>). The <a class="chunk" href="#11iTXt">iTXt</a> chunk can be used to convey
-          characters outside the Latin-1 set. It uses the UTF-8 encoding [[rfc3629]]. There is an option to compress text strings
-          in the <a class="chunk" href="#11iTXt">iTXt</a> chunk.</p>
+          <p>The <a class="chunk" href="#11iTXt">iTXt</a> chunk uses the UTF-8 encoding [[rfc3629]] and 
+            can be used to convey characters in any language. 
+            There is an option to compress text strings
+            in the <a class="chunk" href="#11iTXt">iTXt</a> chunk.
+            <a class="chunk" href="#11iTXt">iTXt</a> is recommended for all text strings, as it supports Unicode.
+            There are also <a class="chunk" href="#11tEXt">tEXt</a> and <a class="chunk" href="#11zTXt">zTXt</a> chunks,
+            whose content is restricted to the printable Latin-1 character set plus U+000A LINE FEED (LF).
+            Text strings in <a class="chunk" href="#11zTXt">zTXt</a> are compressed into <a>zlib</a> datastreams 
+            using <a>deflate</a> compression (see <a href='#10CompressionOtherUses'></a>).  </p>
+
         </section>
         <!-- Maintain a fragment named "11tEXt" to preserve incoming links to it -->
 

--- a/index.html
+++ b/index.html
@@ -1312,8 +1312,7 @@ with these exceptions:
       types of ancillary information provided are described in <a href="#table41"></a>.</p>
       <!-- Maintain a fragment named "table41" to preserve incoming links to it -->
 
-      <table id="table41" class="simple numbered" summary=
-      "This table lists the types of ancillary information that may be associated with an image">
+      <table id="table41" class="simple numbered">
         <caption>
           Types of ancillary information
         </caption>
@@ -1541,7 +1540,7 @@ with these exceptions:
         "chunk" href="#fdAT-chunk">fdAT</a> chunk for the second frame. (<a class="chunk" href="#11IHDR">IHDR</a> and <a class=
         "chunk" href="#11IEND">IEND</a> chunks omitted in these tables, for clarity).</p>
 
-        <table class="numbered simple" summary="sequence numbers, if the static image is also the first frame">
+        <table class="numbered simple">
           <caption>
             If the static image is also the first frame
           </caption>
@@ -1594,7 +1593,7 @@ with these exceptions:
           </tr>
         </table>
 
-        <table class="numbered simple" summary="sequence numbers, if the static image is not part of the animation">
+        <table class="numbered simple">
           <caption>
             If the static image is not part of the animation
           </caption>
@@ -1753,7 +1752,7 @@ with these exceptions:
       </figure>
       <!-- Maintain a fragment named "table51" to preserve incoming links to it -->
 
-      <table id="table51" class="numbered simple" summary="This table defines the chunk fields">
+      <table id="table51" class="numbered simple">
         <caption>
           Chunk fields
         </caption>
@@ -1830,7 +1829,7 @@ with these exceptions:
       <p>The semantics of the property bits are defined in <a href="#table52"></a>.</p>
       <!-- Maintain a fragment named "table52" to preserve incoming links to it -->
 
-      <table id="table52" class="numbered simple" summary="This table defines the semantics of the property bits">
+      <table id="table52" class="numbered simple">
         <caption>
           Semantics of property bits
         </caption>
@@ -1941,7 +1940,7 @@ with these exceptions:
       <!-- ************Page Break******************* -->
       <!-- Maintain a fragment named "table53" to preserve incoming links to it -->
 
-      <table id="table53" class="numbered simple" summary="This table lists the chunk ordering rules">
+      <table id="table53" class="numbered simple">
         <caption>
           Chunk ordering rules
         </caption>
@@ -2201,7 +2200,7 @@ with these exceptions:
       </table>
       <!-- Maintain a fragment named "table54" to preserve incoming links to it -->
 
-      <table id="table54" class="numbered simple" summary="This table lists the symbols used in lattice diagrams">
+      <table id="table54" class="numbered simple">
         <caption>
           Meaning of symbols used in lattice diagrams
         </caption>
@@ -2386,7 +2385,7 @@ with these exceptions:
       alpha channel. The PNG image types and corresponding <a>colour types</a> are listed in <a href="#table6.1"></a>.</p>
       <!-- Maintain a fragment named "table6.1" to preserve incoming links to it -->
 
-      <table id="table6.1" class="numbered simple" summary="This table lists the PNG image and colour types">
+      <table id="table6.1" class="numbered simple">
         <caption>
           PNG image types and colour types
         </caption>
@@ -2663,7 +2662,7 @@ with these exceptions:
 
       <p>Filters may use the original values of the following bytes to generate the new byte value:</p>
 
-      <table class="numbered simple" summary="This table defines the variables used in the filter types table">
+      <table class="numbered simple">
         <caption>
           Named filter bytes
         </caption>
@@ -2723,7 +2722,7 @@ with these exceptions:
       <!-- ************Page Break******************* -->
       <!-- Maintain a fragment named "9-table91" to preserve incoming links to it -->
 
-      <table id="9-table91" class="numbered simple" summary="This table lists the filter types">
+      <table id="9-table91" class="numbered simple">
         <caption>
           Filter types
         </caption>
@@ -2860,7 +2859,7 @@ with these exceptions:
 
       <p><a>Deflate</a>-compressed datastreams within PNG are stored in the <a>zlib</a> format, which has the structure:</p>
 
-      <table summary="This table gives the structure of the zlib format">
+      <table>
         <tr>
           <td>zlib compression method/flags code</td>
           <td>1 byte</td>
@@ -2980,7 +2979,7 @@ with these exceptions:
 </pre>
         <p>The <a class="chunk" href="#11IHDR">IHDR</a> chunk shall be the first chunk in the PNG datastream. It contains:</p>
 
-        <table summary="This table defines the IHDR chunk">
+        <table>
           <tr>
             <td>Width</td>
             <td>4 bytes</td>
@@ -3030,7 +3029,7 @@ with these exceptions:
         that do not compress well. The allowed combinations are defined in <a href="#table111"></a>.</p>
         <!-- Maintain a fragment named "table111" to preserve incoming links to it -->
 
-        <table id="table111" class="numbered simple" summary="This table defines the colour types">
+        <table id="table111" class="numbered simple">
           <caption>
             Allowed combinations of <a>colour type</a> and bit depth
           </caption>
@@ -3107,7 +3106,7 @@ with these exceptions:
         <p>The <span class="chunk">PLTE</span> chunk contains from 1 to 256 palette entries, each a three-byte series of the
         form:</p>
 
-        <table summary="This table defines the PLTE palette table entries">
+        <table>
           <tr>
             <td>Red</td>
             <td>1 byte</td>
@@ -3210,7 +3209,7 @@ with these exceptions:
           "chunk">tRNS</span> chunk contains: <!-- ************Page Break******************* --></p>
           <!-- ************Page Break******************* -->
 
-          <table summary="This table defines the tRNS chunk">
+          <table>
             <tr>
               <th colspan="2">
                 <a>Colour type</a> 0
@@ -3312,7 +3311,7 @@ with these exceptions:
           <!-- ************Page Break******************* -->
           <!-- ************Page Break******************* -->
 
-          <table class="numbered simple" summary="This table defines the cHRM chunk">
+          <table class="numbered simple">
             <caption>
               cHRM chunk components
             </caption>
@@ -3395,7 +3394,7 @@ with these exceptions:
 
           <p>The <span class="chunk">gAMA</span> chunk contains:</p>
 
-          <table summary="This table defines the gAMA chunk">
+          <table>
             <tr>
               <td>Image gamma</td>
               <td>4 bytes</td>
@@ -3423,7 +3422,7 @@ with these exceptions:
 </pre>
           <p>The <span class="chunk">iCCP</span> chunk contains:</p>
 
-          <table summary="This table defines the iCCP chunk">
+          <table>
             <tr>
               <td>Profile name</td>
               <td>1-79 bytes (character string)</td>
@@ -3488,7 +3487,7 @@ with these exceptions:
           <!-- ************Page Break******************* -->
           <!-- ************Page Break******************* -->
 
-          <table class="numbered simple" summary="This table defines the sBIT chunk">
+          <table class="numbered simple">
             <caption>
               sBIT chunk contents
             </caption>
@@ -3583,7 +3582,7 @@ with these exceptions:
 
           <p>The <span class="chunk">sRGB</span> chunk contains:</p>
 
-          <table class="numbered simple" summary="This table defines the sRGB chunk">
+          <table class="numbered simple">
             <caption>
               sRGB chunk contents
             </caption>
@@ -3601,7 +3600,7 @@ with these exceptions:
 
           <p>The following values are defined for rendering intent:</p>
 
-          <table class="numbered simple" summary="This table defines the values of rendering intent in the sRGB chunk">
+          <table class="numbered simple">
             <caption>
               Rendering intent values
             </caption>
@@ -3646,7 +3645,7 @@ with these exceptions:
           "chunk" href="#11gAMA">gAMA</a> chunk (and optionally a <a class="chunk" href="#11cHRM">cHRM</a> chunk) for compatibility
           with decoders that do not use the <span class="chunk">sRGB</span> chunk. Only the following values shall be used.</p>
 
-          <table class="numbered simple" summary="This table defines the gAMA and cHRM values for sRGB">
+          <table class="numbered simple">
             <caption>
               gAMA and cHRM values for sRGB
             </caption>
@@ -4007,7 +4006,7 @@ with these exceptions:
 
           <p>The following keywords are predefined and should be used where appropriate.</p>
 
-          <table class="numbered simple" summary="This table defines the keywords defined for tEXt, iTXt and zTXt chunks">
+          <table class="numbered simple">
             <caption>
               Predefined keywords
             </caption>
@@ -4125,7 +4124,7 @@ with these exceptions:
 </pre>
           <p>Each <span class="chunk">tEXt</span> chunk contains a keyword and a text string, in the format:</p>
 
-          <table summary="This table defines the tEXt chunk">
+          <table>
             <tr>
               <td>Keyword</td>
               <td>1-79 bytes (character string)</td>
@@ -4171,7 +4170,7 @@ with these exceptions:
 
           <p>A <span class="chunk">zTXt</span> chunk contains:</p>
 
-          <table summary="This table defines the zTXt chunk">
+          <table>
             <tr>
               <td>Keyword</td>
               <td>1-79 bytes (character string)</td>
@@ -4213,7 +4212,7 @@ with these exceptions:
 </pre>
           <p>An <span class="chunk">iTXt</span> chunk contains:</p>
 
-          <table summary="This table defines the iTXt chunk">
+          <table>
             <tr>
               <td>Keyword</td>
               <td>1-79 bytes (character string)</td>
@@ -4306,7 +4305,7 @@ with these exceptions:
           is any other preferred background, either user-specified or part of a larger page (as in a browser), the <span class=
           "chunk">bKGD</span> chunk should be ignored. The <span class="chunk">bKGD</span> chunk contains:</p>
 
-          <table class="numbered simple" summary="This table defines the bKGD chunk">
+          <table class="numbered simple">
             <caption>
               bKGD chunk contents
             </caption>
@@ -4369,7 +4368,7 @@ with these exceptions:
 </pre>
           <p>The <span class="chunk">hIST</span> chunk contains a series of two-byte unsigned integers:</p>
 
-          <table summary="This table defines the hIST chunk">
+          <table>
             <tr>
               <td>Frequency</td>
               <td>2 bytes (unsigned integer)</td>
@@ -4410,7 +4409,7 @@ with these exceptions:
           <p>The <span class="chunk">pHYs</span> chunk specifies the intended pixel size or aspect ratio for display of the image.
           It contains:</p>
 
-          <table class="numbered simple" summary="This table defines the pHYs chunk">
+          <table class="numbered simple">
             <caption>
               pHYs chunk contents
             </caption>
@@ -4442,7 +4441,7 @@ with these exceptions:
 
           <p>The following values are defined for the unit specifier:</p>
 
-          <table class="numbered simple" summary="This table defines the allowed values for the unit specifier in the pHYs chunk">
+          <table class="numbered simple">
             <caption>
               Unit specifier values
             </caption>
@@ -4481,7 +4480,7 @@ with these exceptions:
 </pre>
           <p>The <span class="chunk">sPLT</span> chunk contains:</p>
 
-          <table class="numbered simple" summary="This table defines the sPLT chunk">
+          <table class="numbered simple">
             <caption>
               sPLT chunk contents
             </caption>
@@ -4652,7 +4651,7 @@ with these exceptions:
           <p>The <span class="chunk">tIME</span> chunk gives the time of the last image modification (<strong>not</strong> the time
           of initial image creation). It contains:</p>
 
-          <table class="numbered simple" summary="This table defines the tIME chunk">
+          <table class="numbered simple">
             <caption>
               tIME chunk contents
             </caption>
@@ -4714,7 +4713,7 @@ with these exceptions:
           <p>The <span class="chunk">acTL</span> chunk declares that this is an animated PNG image, gives the number of frames, and
           the number of times to loop. It contains:</p>
 
-          <table summary="This table defines the acTL chunk">
+          <table>
             <tr>
               <td>`num_frames`</td>
               <td>4 bytes</td>
@@ -4753,7 +4752,7 @@ with these exceptions:
           <p>The <span class="chunk">fcTL</span> chunk defines the dimensions, position, delay and disposal of an individual frame.
           Exactly one <span class="chunk">fcTL</span> chunk chunk is required for each frame. It contains:</p>
 
-          <table class="numbered simple" summary="This table defines the fcTL chunk">
+          <table class="numbered simple">
             <caption>
               fcTL chunk contents
             </caption>
@@ -4838,7 +4837,7 @@ with these exceptions:
 
           <p>Valid values for `dispose_op` are:</p>
 
-          <table summary="This table defines the disposal operators">
+          <table>
             <tr>
               <td>0</td>
               <td>`APNG_DISPOSE_OP_NONE`</td>
@@ -4879,7 +4878,7 @@ with these exceptions:
 
           <p>Valid values for `blend_op` are:</p>
 
-          <table summary="This table defines the blend operators">
+          <table>
             <tr>
               <td>0</td>
               <td>`APNG_BLEND_OP_SOURCE`</td>
@@ -4941,7 +4940,7 @@ with these exceptions:
           "#11IDAT">IDAT</a> chunk does for static images; it contains the <a>image data</a> for all frames (or, for animations
           which include the <a>static image</a> as first frame, for all frames after the first one). It contains:</p>
 
-          <table class="numbered simple" summary="This table defines the fdAT chunk">
+          <table class="numbered simple">
             <caption>
               fdAT chunk contents
             </caption>
@@ -5184,7 +5183,7 @@ cHRM</a> chunk.</p>-->
       <!-- ************Page Break******************* -->
       <!-- Maintain a fragment named "12-table121" to preserve incoming links to it -->
 
-      <table id="12-table121" class="numbered simple" summary="CCIR 709 primaries and D65 whitepoint">
+      <table id="12-table121" class="numbered simple">
         <caption>
           CCIR 709 primaries and D65 whitepoint
         </caption>
@@ -5217,7 +5216,7 @@ cHRM</a> chunk.</p>-->
       <p>An older but still very popular video standard is SMPTE-C [[SMPTE 170M]] given in <a href="#12-table122"></a>.</p>
       <!-- Maintain a fragment named "12-table122" to preserve incoming links to it -->
 
-      <table id="12-table122" class="numbered simple" summary="CSMPTE-C video standard">
+      <table id="12-table122" class="numbered simple">
         <caption>
           SMPTE-C video standard
         </caption>
@@ -6926,10 +6925,8 @@ will need to be replaced by copies of lines 17-23, but processing background ins
           <dd>None</dd>
     
           <dt>Published specification:</dt>
-          <dd><a href="https://www.w3.org/TR/png/
-            ">Portable Network Graphics (PNG) Specification</a>,
-            <a href="https://www.w3.org/TR/png/
-            ">https://www.w3.org/TR/png/</a>
+          <dd><a href="https://www.w3.org/TR/png/">Portable Network Graphics (PNG) Specification</a>,
+            <a href="https://www.w3.org/TR/png/">https://www.w3.org/TR/png/</a>
           </dd>
     
           <dt>Applications which use this media:</dt>
@@ -7049,7 +7046,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
     non-linear <a>transfer functions</a> may occur and which may be modelled by power laws. The characteristic exponent associated
     with each is given a specific name.</p>
 
-    <table summary="This table describes characteristic exponents">
+    <table>
       <tr>
         <td><var>input_exponent</var>
         </td>
@@ -7093,7 +7090,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
     <p>It is convenient to define some additional entities that describe some composite <a>transfer functions</a>, or combinations
     of stages.</p>
 
-    <table summary="This table characterises additional entities that are used to describe transfer functions">
+    <table>
       <tr>
         <td><var>display_exponent</var>
         </td>
@@ -7147,7 +7144,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
     users to read the code more easily.</p>
     <!-- Maintain a fragment named "D-tabled1" to preserve incoming links to it -->
 
-    <table id="D-tabled1" class="numbered simple" summary="This table gives hints for reading the CRC code">
+    <table id="D-tabled1" class="numbered simple">
       <caption>
         Hints for reading ISO C code
       </caption>

--- a/index.html
+++ b/index.html
@@ -3888,6 +3888,87 @@ with these exceptions:
 
           <p>The <span class="chunk">mASt</span> chunk MUST come before the <a class="chunk" href="#11PLTE">PLTE</a> and <a class=
           "chunk" href="#11IDAT">IDAT</a> chunks.</p>
+
+          <aside class="example">
+            Example <span class="chunk">mASt</span> chunk mastering display colour primaries:
+            <table id="mASt-chunk-primaries-example" class="numbered simple">
+              <tr>
+                <th>Name</th>
+                <th>Values</th>
+              </tr>
+
+              <tr>
+                <td rowspan="3">Colour primaries specified in [[ITU-R BT.709]]</td>
+                <td>{ 32000, 16500 }</td>
+              </tr>
+
+              <tr>
+                <td>{ 15000, 30000 }</td>
+              </tr>
+
+              <tr>
+                <td>{ 7500, 3000 }</td>
+              </tr>
+
+              <tr>
+                <td rowspan="3">Colour primaries specified in [[ITU-R BT.2020]]</td>
+                <td>{ 35400, 14600 }</td>
+              </tr>
+
+              <tr>
+                <td>{ 8500, 39850 }</td>
+              </tr>
+
+              <tr>
+                <td>{ 6550, 2300 }</td>
+              </tr>
+            </table>
+          </aside>
+
+          <aside class="example">
+            Example <span class="chunk">mASt</span> chunk mastering display white point:
+            <table id="mASt-chunk-white-point-example" class="numbered simple">
+              <tr>
+                <th>Name</th>
+                <th>Values</th>
+              </tr>
+
+              <tr>
+                <td>Illuminant D65 specified in [[SMPTE RP 177]]</td>
+                <td>{ 15635, 16450 }</td>
+              </tr>
+            </table>
+          </aside>
+
+          <aside class="example">
+            Example <span class="chunk">mASt</span> chunk mastering display maximum luminance:
+            <table id="mASt-chunk-max-luminance-example" class="numbered simple">
+              <tr>
+                <th>Name</th>
+                <th>Values</th>
+              </tr>
+
+              <tr>
+                <td>4000 cd/m<sup>2</sup></td>
+                <td>40000000</td>
+              </tr>
+            </table>
+          </aside>
+
+          <aside class="example">
+            Example <span class="chunk">mASt</span> chunk mastering display minimum luminance:
+            <table id="mASt-chunk-min-luminance-example" class="numbered simple">
+              <tr>
+                <th>Name</th>
+                <th>Values</th>
+              </tr>
+
+              <tr>
+                <td>0.005 cd/m<sup>2</sup></td>
+                <td>50</td>
+              </tr>
+            </table>
+          </aside>
         </section>
       </section>
       <!-- Maintain a fragment named "11textinfo" to preserve incoming links to it -->

--- a/index.html
+++ b/index.html
@@ -3873,6 +3873,11 @@ with these exceptions:
               <td>Mastering display maximum luminance</td>
               <td>4 bytes</td>
             </tr>
+
+            <tr>
+              <td>Mastering display minimum luminance</td>
+              <td>4 bytes</td>
+            </tr>
           </table>
 
           <aside class="note">

--- a/index.html
+++ b/index.html
@@ -3945,7 +3945,7 @@ with these exceptions:
             <table id="mASt-chunk-max-luminance-example" class="numbered simple">
               <tr>
                 <th>Name</th>
-                <th>Values</th>
+                <th>Value</th>
               </tr>
 
               <tr>
@@ -3960,7 +3960,7 @@ with these exceptions:
             <table id="mASt-chunk-min-luminance-example" class="numbered simple">
               <tr>
                 <th>Name</th>
-                <th>Values</th>
+                <th>Value</th>
               </tr>
 
               <tr>

--- a/index.html
+++ b/index.html
@@ -3844,8 +3844,8 @@ with these exceptions:
           <pre>
 109 65 83 116
 </pre>
-          <p>If present, the <span class="chunk">mASt</span> chunk specifies the mastering display's metadata which includes
-          primaries, white point, maximum luminance, and minimum luminance as specified in [[SMPTE ST 2086]].</p>
+          <p>If present, the <span class="chunk">mASt</span> chunk specifies the mastering display's metadata as specified in
+          [[SMPTE ST 2086]].</p>
 
           <p>The following specifies the syntax of the <span class="chunk">mASt</span> chunk:</p>
 

--- a/index.html
+++ b/index.html
@@ -283,8 +283,6 @@ with these exceptions:
 
   <h2 id="Introduction">Introduction</h2>
 
-  <p>
-  </p>
 
   <p>The design goals for this specification were:</p>
 
@@ -2543,8 +2541,6 @@ with these exceptions:
       <p>A <dfn id="3filter">filter method</dfn> is a transformation applied to an array of <a>scanlines</a> with the aim of
       improving their compressibility.</p>
 
-      <p>
-      </p>
 
       <p>PNG standardizes one <a>filter method</a> and several filter types that may be used to prepare <a>image data</a> for
       compression. It transforms the byte sequence into an equal length sequence of bytes preceded by a filter type byte (see
@@ -2735,7 +2731,7 @@ with these exceptions:
         </tr>
 
         <tr>
-          <td align="center">0</td>
+          <td>0</td>
           <td>None</td>
           <td><code>Filt(x) = Orig(x)</code>
           </td>
@@ -2744,7 +2740,7 @@ with these exceptions:
         </tr>
 
         <tr>
-          <td align="center">1</td>
+          <td>1</td>
           <td>Sub</td>
           <td><code>Filt(x) = Orig(x) - Orig(a)</code>
           </td>
@@ -2753,7 +2749,7 @@ with these exceptions:
         </tr>
 
         <tr>
-          <td align="center">2</td>
+          <td>2</td>
           <td>Up</td>
           <td><code>Filt(x) = Orig(x) - Orig(b)</code>
           </td>
@@ -2762,7 +2758,7 @@ with these exceptions:
         </tr>
 
         <tr>
-          <td align="center">3</td>
+          <td>3</td>
           <td>Average</td>
           <td><code>Filt(x) = Orig(x) - floor((Orig(a) + Orig(b)) / 2)</code>
           </td>
@@ -2771,7 +2767,7 @@ with these exceptions:
         </tr>
 
         <tr>
-          <td align="center">4</td>
+          <td>4</td>
           <td>Paeth</td>
           <td><code>Filt(x) = Orig(x) - PaethPredictor(Orig(a), Orig(b), Orig(c))</code>
           </td>
@@ -3043,21 +3039,21 @@ with these exceptions:
 
           <tr>
             <td>Greyscale</td>
-            <td align="center">0</td>
+            <td>0</td>
             <td>1, 2, 4, 8, 16</td>
             <td>Each pixel is a greyscale sample</td>
           </tr>
 
           <tr>
             <td>Truecolour</td>
-            <td align="center">2</td>
+            <td>2</td>
             <td>8, 16</td>
             <td>Each pixel is an R,G,B triple</td>
           </tr>
 
           <tr>
             <td>Indexed-colour</td>
-            <td align="center">3</td>
+            <td>3</td>
             <td>1, 2, 4, 8</td>
             <td>
               Each pixel is a palette index; a <a class="chunk" href="#11PLTE">PLTE</a> chunk shall appear.
@@ -3066,14 +3062,14 @@ with these exceptions:
 
           <tr>
             <td>Greyscale with alpha</td>
-            <td align="center">4</td>
+            <td>4</td>
             <td>8, 16</td>
             <td>Each pixel is a greyscale sample followed by an alpha sample.</td>
           </tr>
 
           <tr>
             <td>Truecolour with alpha</td>
-            <td align="center">6</td>
+            <td>6</td>
             <td>8, 16</td>
             <td>Each pixel is an R,G,B triple followed by an alpha sample.</td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -206,6 +206,12 @@
           date: "2013-01-01",
           href: "https://doi.org/10.5594/SMPTE.RP2077.2013"
         },
+        "SMPTE ST 2086": {
+          title: "Mastering Display Color Volume Metadata Supporting High Luminance and Wide Color Gamut Images",
+          publisher: "Society of Motion Picture and Television Engineers",
+          date: "27 April 2018",
+          href: "https://ieeexplore.ieee.org/document/8353899"
+        },
         "TIFF 6.0": {
           href: "https://www.loc.gov/preservation/digital/formats/fdd/fdd000022.shtml",
           title: "TIFF Revision 6.0",
@@ -310,9 +316,9 @@ with these exceptions:
     Internet. Indexed-colour, greyscale, and <a>truecolour</a> images are supported, with optional transparency. Sample depths
     range from 1 to 16 bits. PNG is fully streamable with a progressive display option. It is robust, providing both full file
     integrity checking and simple detection of common transmission errors. PNG can store <a>gamma value</a> and chromaticity data
-    as well as a full ICC colour profile or CICP image format signaling metadata, for accurate colour matching on heterogenous
-    platforms. This Standard defines the Internet Media types "image/png" and "image/apng". The datastream and associated file
-    format have value outside of the main design goal.</p>
+    as well as a full ICC colour profile, CICP image format signaling metadata, and mastering metadata for accurate colour matching
+    on heterogeneous platforms. This Standard defines the Internet Media types "image/png" and "image/apng". The datastream and
+    associated file format have value outside of the main design goal.</p>
   </section>
 
   <section>
@@ -977,6 +983,8 @@ with these exceptions:
 
       <p><a>Gamma</a> correction is not applied to the alpha channel, if present. Alpha samples always represent a linear fraction
       of full opacity.</p>
+
+      <p>Mastering metadata may also be provided</p>
     </section>
     <!-- Maintain a fragment named "4Concepts.PNGImageTransformation" to preserve incoming links to it -->
 
@@ -1402,7 +1410,7 @@ with these exceptions:
       <section id="4Concepts.FormatTypes">
         <h2>Chunk types</h2>
 
-        <p>There are 19 chunk types defined in this International Standard. Chunk types are four-byte sequences chosen so that they
+        <p>There are 24 chunk types defined in this International Standard. Chunk types are four-byte sequences chosen so that they
         correspond to readable labels when interpreted in the ISO 646.IRV:1991 [[ISO646]] character set. The first four are termed
         critical chunks, which shall be understood and correctly interpreted according to the provisions of this specification.
         These are:</p>
@@ -1426,7 +1434,7 @@ with these exceptions:
           </li>
         </ol>
 
-        <p>The remaining 18 chunk types are termed ancillary chunk types, which encoders may generate and decoders may
+        <p>The remaining 20 chunk types are termed ancillary chunk types, which encoders may generate and decoders may
         interpret.</p>
         <!-- <ol start="5"> -->
 
@@ -1436,7 +1444,8 @@ with these exceptions:
 
           <li>Colour space information: <a class="chunk" href="#11cHRM">cHRM</a>, <a class="chunk" href="#11gAMA">gAMA</a>,
           <a class="chunk" href="#11iCCP">iCCP</a>, <a class="chunk" href="#11sBIT">sBIT</a>, <a class="chunk" href=
-          "#11sRGB">sRGB</a>, <a class="chunk" href="#cICP-chunk">cICP</a> (see <a href="#11addnlcolinfo"></a>).
+          "#11sRGB">sRGB</a>, <a class="chunk" href="#cICP-chunk">cICP</a>, <a class="chunk" href="#mASt-chunk">mASt</a> (see
+          <a href="#11addnlcolinfo"></a>).
           </li>
 
           <li>Textual information: <a class="chunk" href="#11iTXt">iTXt</a>, <a class="chunk" href="#11tEXt">tEXt</a>, <a class=
@@ -2030,6 +2039,16 @@ with these exceptions:
           <td>
             Before <a class="chunk" href="#11PLTE">PLTE</a> and <a class="chunk" href="#11IDAT">IDAT</a>. If the <a class="chunk"
             href="#11iCCP">iCCP</a> chunk is present, the <a class="chunk" href="#11sRGB">sRGB</a> chunk should not be present.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            <a class="chunk" href="#mASt-chunk">mASt</a>
+          </td>
+          <td>No</td>
+          <td>
+            Before <a class="chunk" href="#11PLTE">PLTE</a> and <a class="chunk" href="#11IDAT">IDAT</a>.
           </td>
         </tr>
 
@@ -3758,7 +3777,8 @@ with these exceptions:
             carriage.
           </aside>
 
-          <p>The <span class="chunk">cICP</span> chunk MUST come before the <a class="chunk" href="#11IDAT">IDAT</a> chunk.</p>
+          <p>The <span class="chunk">cICP</span> chunk MUST come before the <a class="chunk" href="#11PLTE">PLTE</a> and <a class=
+          "chunk" href="#11IDAT">IDAT</a> chunks.</p>
 
           <p>When the <span class="chunk">cICP</span> chunk is present, decoders that recognize it SHALL ignore the following
           chunks:</p>
@@ -3815,6 +3835,56 @@ with these exceptions:
 1 1 0 0
 </pre>
           </aside>
+        </section>
+        <!-- Maintain a fragment named "mASt-chunk" to preserve incoming links to it -->
+
+        <section id="mASt-chunk">
+          <h2><span class="chunk">mASt</span> mastering metadata</h2>
+
+          <p>The four decimal values below correspond to the four-byte mASt chunk type field:</p>
+
+          <pre>
+109 65 83 116
+</pre>
+          <p>If present, the <span class="chunk">mASt</span> chunk specifies the mastering display's metadata which includes
+          primaries, white point, maximum luminance, and minimum luminance as specified in [[SMPTE ST 2086]].</p>
+
+          <p>The following specifies the syntax of the <span class="chunk">mASt</span> chunk:</p>
+
+          <table id="mASt-chunk-syntax" class="numbered simple">
+            <caption>
+              mASt chunk components
+            </caption>
+
+            <tr>
+              <th>Name</th>
+              <th>Size</th>
+            </tr>
+
+            <tr>
+              <td>Mastering display colour primaries</td>
+              <td>12 bytes</td>
+            </tr>
+
+            <tr>
+              <td>Mastering display white point chromaticity</td>
+              <td>4 bytes</td>
+            </tr>
+
+            <tr>
+              <td>Mastering display maximum luminance</td>
+              <td>4 bytes</td>
+            </tr>
+          </table>
+
+          <aside class="note">
+            The three colour primaries are 4 bytes each, totalling 12 bytes. They are ordered starting with the primary with the
+            largest x chromaticity, followed by the primary with the largest y chromaticity, followed by the remaining primary.
+            This corresponds to RGB order.
+          </aside>
+
+          <p>The <span class="chunk">mASt</span> chunk MUST come before the <a class="chunk" href="#11PLTE">PLTE</a> and <a class=
+          "chunk" href="#11IDAT">IDAT</a> chunks.</p>
         </section>
       </section>
       <!-- Maintain a fragment named "11textinfo" to preserve incoming links to it -->
@@ -7154,6 +7224,10 @@ will need to be replaced by copies of lines 17-23, but processing background ins
 
       <li>The previously defined <a class="chunk" href="#eXIf">eXIf</a> chunk has been moved from the PNG-Extensions document
       [[PNG-EXTENSIONS]] into the main body of this specification, to reflect it's widespready use.
+      </li>
+
+      <li>Added the <a class="chunk" href="#mASt-chunk">mASt</a> chunk, which contains metadata about the display used in
+      mastering. This enabled more accurate colour matching on heterogeneous platforms
       </li>
 
       <li>Incorporation of all <a href="https://www.w3.org/2003/11/REC-PNG-20031110-errata">PNG Second Edition Errata</a>

--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
       wgURI: "https://www.w3.org/groups/wg/png",
       wgPublicList: "public-png",
       wgPatentURI: "https://www.w3.org/groups/wg/png/ipr",
+      xref: ["i18n-glossary"],
       localBiblio: {
         "CIPA DC-008": {
           title: "Exchangeable image file format for digital still cameras: Exif Version 2.32",
@@ -5476,16 +5477,22 @@ output = floor((input * MAXOUTSAMPLE / MAXINSAMPLE) + 0.5)
       description of the text is available. If a user-supplied keyword is used, encoders should check that it meets the
       restrictions on keywords.</p>
 
-      <p>For the <a class="chunk" href="#11tEXt">tEXt</a> and <a class="chunk" href="#11zTXt">zTXt</a> chunks, PNG text strings are
-      expected to use the Latin-1 character set. Encoders should avoid storing characters that are not defined in Latin-1, and
-      should provide character code remapping if the local system's character set is not Latin-1. The <a class="chunk" href=
-      "#11iTXt">iTXt</a> chunk provides support for international text, represented using the UTF-8 encoding of UCS. Encoders
-      should discourage the creation of single lines of text longer than 79 characters, in order to facilitate easy reading. It is
-      recommended that text items less than 1024 bytes in size should be output using uncompressed text chunks. It is recommended
-      that the basic title and author keywords be output using uncompressed text chunks. Placing large text chunks after the
-      <a>image data</a> (after the <a class="chunk" href="#11IDAT">IDAT</a> chunks) can speed up image display in some situations,
+      <p>The <a class="chunk" href="#11iTXt">iTXt</a> chunk uses the UTF-8 encoding of Unicode 
+      and thus can store text in any language. The <a class="chunk" href="#11tEXt">tEXt</a> and <a class="chunk" href="#11zTXt">zTXt</a> chunks use the Latin-1 (ISO 8859-1) character encoding, 
+      which limits the range of characters that can be used in these chunks. 
+      Encoders should prefer <a class="chunk" href="#11iTXt">iTXt</a> to 
+      <a class="chunk" href="#11tEXt">tEXt</a> and <a class="chunk" href="#11zTXt">zTXt</a> chunks.
+      in order to allow a wide range of characters without data loss. 
+      Encoders must convert characters that use local <a>legacy character encodings</a>
+      to the appropriate encoding when storing text.
+      Encoders should discourage the creation of single lines of text longer than 79 Unicode <a>code points</a>, 
+      in order to facilitate easy reading. 
+      It is recommended that text items less than 1024 bytes in size should be output using uncompressed text chunks. 
+      It is recommended that the basic title and author keywords be output using uncompressed text chunks. 
+      Placing large text chunks after the <a>image data</a> (after the <a class="chunk" href="#11IDAT">IDAT</a> chunks) can speed up image display in some situations,
       as the decoder will decode the <a>image data</a> first. It is recommended that small text chunks, such as the image title,
       appear before the <a class="chunk" href="#11IDAT">IDAT</a> chunks.</p>
+
     </section>
     <!-- ************Page Break******************* -->
     <!-- ************Page Break******************* -->

--- a/index.html
+++ b/index.html
@@ -136,6 +136,11 @@
           publisher: "ITU",
           href: "https://www.itu.int/rec/R-REC-BT.709"
         },
+        "ITU-R BT.2020": {
+          title: "Parameter values for ultra-high definition television systems for production and international programme exchange",
+          publisher: "ITU",
+          href: "https://www.itu.int/rec/R-REC-BT.2020"
+        },
         "ITU-R BT.2100": {
           title: "ITU-R BT.2100, SERIES H: AUDIOVISUAL AND MULTIMEDIA SYSTEMS Infrastructure of audiovisual services – Coding of moving video Coding-independent code points for video signal type identification",
           publisher: "ITU",
@@ -199,6 +204,12 @@
           publisher: "Society of Motion Picture and Television Engineers",
           date: "2004-11-30",
           href: "https://standards.globalspec.com/std/892300/SMPTE%20ST%20170M"
+        },
+        "SMPTE RP 177": {
+          title: "Derivation of Basic Television Color Equations",
+          publisher: "Society of Motion Picture and Television Engineers",
+          date: "1 November 1993",
+          href: "https://standards.globalspec.com/std/1284890/smpte-rp-177"
         },
         "SMPTE RP 2077": {
           title: "Full-Range Image Mapping",

--- a/index.html
+++ b/index.html
@@ -6970,6 +6970,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
               brings official documentation into alignment with already 
               widely-deployed reality. 
           </p>
+          </dd>
     
           <dt>Person to contact for further information:</dt>
           <dd>

--- a/index.html
+++ b/index.html
@@ -3867,33 +3867,44 @@ with these exceptions:
             <tr>
               <th>Name</th>
               <th>Size</th>
+              <th>Physical units</th>
             </tr>
 
             <tr>
               <td>Mastering display colour primaries</td>
               <td>12 bytes</td>
+              <td>0.00002</td>
             </tr>
 
             <tr>
               <td>Mastering display white point chromaticity</td>
               <td>4 bytes</td>
+              <td>0.00002</td>
             </tr>
 
             <tr>
               <td>Mastering display maximum luminance</td>
               <td>4 bytes</td>
+              <td>0.0001 cd/m<sup>2</sup></td>
             </tr>
 
             <tr>
               <td>Mastering display minimum luminance</td>
               <td>4 bytes</td>
+              <td>0.0001 cd/m<sup>2</sup></td>
             </tr>
           </table>
 
           <aside class="note">
-            The three colour primaries are 4 bytes each, totalling 12 bytes. They are ordered starting with the primary with the
-            largest x chromaticity, followed by the primary with the largest y chromaticity, followed by the remaining primary.
-            This corresponds to RGB order.
+            The three colour primaries are 4 bytes each, totalling 12 bytes. Each primary and the white point is comprised of a
+            2-byte unsigned integer x and 2-byte unsigned integer y. They are ordered starting with the primary with the largest x
+            chromaticity, followed by the primary with the largest y chromaticity, followed by the remaining primary. This
+            corresponds to RGB order.
+          </aside>
+
+          <aside class="note">
+            The physical units act as a multiplier. For example, the unitless value of 0.00002 for the primaries and white point
+            would store the chromaticity (0.6800, 0.3200) as {34000, 16000}.
           </aside>
 
           <p>The <span class="chunk">mASt</span> chunk MUST come before the <a class="chunk" href="#11PLTE">PLTE</a> and <a class=

--- a/index.html
+++ b/index.html
@@ -3903,8 +3903,8 @@ with these exceptions:
           </aside>
 
           <aside class="note">
-            The physical units act as a multiplier. For example, the unitless value of 0.00002 for the primaries and white point
-            would store the chromaticity (0.6800, 0.3200) as {34000, 16000}.
+            The physical units act as a divisor. For example, the unitless value of 0.00002 for the primaries and white point would
+            store the chromaticity (0.6800, 0.3200) as {34000, 16000}.
           </aside>
 
           <p>The <span class="chunk">mASt</span> chunk MUST come before the <a class="chunk" href="#11PLTE">PLTE</a> and <a class=
@@ -3915,32 +3915,39 @@ with these exceptions:
             <table id="mASt-chunk-primaries-example" class="numbered simple">
               <tr>
                 <th>Name</th>
-                <th>Values</th>
+                <th>Physical units</th>
+                <th>Stored values</th>
               </tr>
 
               <tr>
                 <td rowspan="3">Colour primaries specified in [[ITU-R BT.709]]</td>
+                <td>(0.640, 0.330)</td>
                 <td>{ 32000, 16500 }</td>
               </tr>
 
               <tr>
+                <td>(0.300, 0.600)</td>
                 <td>{ 15000, 30000 }</td>
               </tr>
 
               <tr>
+                <td>(0.150, 0.060)</td>
                 <td>{ 7500, 3000 }</td>
               </tr>
 
               <tr>
                 <td rowspan="3">Colour primaries specified in [[ITU-R BT.2020]]</td>
+                <td>(0.708, 0.292)</td>
                 <td>{ 35400, 14600 }</td>
               </tr>
 
               <tr>
+                <td>(0.170, 0.797)</td>
                 <td>{ 8500, 39850 }</td>
               </tr>
 
               <tr>
+                <td>(0.131, 0.046)</td>
                 <td>{ 6550, 2300 }</td>
               </tr>
             </table>
@@ -3951,11 +3958,13 @@ with these exceptions:
             <table id="mASt-chunk-white-point-example" class="numbered simple">
               <tr>
                 <th>Name</th>
-                <th>Values</th>
+                <th>Physical units</th>
+                <th>Stored values</th>
               </tr>
 
               <tr>
                 <td>Illuminant D65 specified in [[SMPTE RP 177]]</td>
+                <td>(0.3127, 0.3290)</td>
                 <td>{ 15635, 16450 }</td>
               </tr>
             </table>
@@ -3965,8 +3974,8 @@ with these exceptions:
             Example <span class="chunk">mASt</span> chunk mastering display maximum luminance:
             <table id="mASt-chunk-max-luminance-example" class="numbered simple">
               <tr>
-                <th>Name</th>
-                <th>Value</th>
+                <th>Physical units</th>
+                <th>Stored value</th>
               </tr>
 
               <tr>
@@ -3980,8 +3989,8 @@ with these exceptions:
             Example <span class="chunk">mASt</span> chunk mastering display minimum luminance:
             <table id="mASt-chunk-min-luminance-example" class="numbered simple">
               <tr>
-                <th>Name</th>
-                <th>Value</th>
+                <th>Physical units</th>
+                <th>Stored value</th>
               </tr>
 
               <tr>

--- a/index.html
+++ b/index.html
@@ -3855,7 +3855,7 @@ with these exceptions:
           <pre>
 109 65 83 116
 </pre>
-          <p>If present, the <span class="chunk">mASt</span> chunk specifies the mastering display's metadata as specified in
+          <p>If present, the <span class="chunk">mASt</span> chunk characterizes the display used at mastering, as specified in
           [[SMPTE ST 2086]].</p>
 
           <p>The following specifies the syntax of the <span class="chunk">mASt</span> chunk:</p>

--- a/index.html
+++ b/index.html
@@ -132,8 +132,9 @@
           publisher: "ISO"
         },
         "ITU-R BT.709": {
-          title: "ITU-R BT.709, SERIES H: AUDIOVISUAL AND MULTIMEDIA SYSTEMS Infrastructure of audiovisual services – Coding of moving video Coding-independent code points for video signal type identification",
+          title: "ITU-R BT.709, SERIES BT: BROADCASTING SERVICE (TELEVISION). Parameter values for the HDTV standards for production and international programme exchange",
           publisher: "ITU",
+          date: "2015-06",
           href: "https://www.itu.int/rec/R-REC-BT.709"
         },
         "ITU-R BT.2020": {
@@ -142,17 +143,19 @@
           href: "https://www.itu.int/rec/R-REC-BT.2020"
         },
         "ITU-R BT.2100": {
-          title: "ITU-R BT.2100, SERIES H: AUDIOVISUAL AND MULTIMEDIA SYSTEMS Infrastructure of audiovisual services – Coding of moving video Coding-independent code points for video signal type identification",
+          title: "ITU-R BT.2100, SERIES BT: BROADCASTING SERVICE (TELEVISION). Image parameter values for high dynamic range television for use in production and international programme exchange",
           publisher: "ITU",
+          date: "2018-07",
           href: "https://www.itu.int/rec/R-REC-BT.2100"
         },
         "ITU-T H.273": {
-          title: "ITU-T H.273, SERIES H: AUDIOVISUAL AND MULTIMEDIA SYSTEMS Infrastructure of audiovisual services – Coding of moving video Coding-independent code points for video signal type identification",
+          title: "ITU-T H.273, SERIES H: AUDIOVISUAL AND MULTIMEDIA SYSTEMS Infrastructure of audiovisual services – Coding of moving video. Coding-independent code points for video signal type identification",
           publisher: "ITU",
+          date: "2021-07",
           href: "https://www.itu.int/rec/T-REC-H.273"
         },
         "ITU-T V.42": {
-          title: "ITU Recommendation V.42 : Error-correcting procedures for DCEs using asynchronous-to-synchronous conversion",
+          title: "ITU-T V.42, SERIES V: DATA COMMUNICATION OVER THE TELEPHONE NETWORK. Error-correcting procedures for DCEs using asynchronous-to-synchronous conversion",
           href: "https://www.itu.int/rec/T-REC-V.42-200203-I/en",
           date: "2002-03-29",
           publisher: "ITU"

--- a/index.html
+++ b/index.html
@@ -4259,11 +4259,11 @@ with these exceptions:
           is 0 (<a>zlib</a> datastream with <a>deflate</a> compression, see <a href='#10CompressionOtherUses'></a>). For
           uncompressed text, encoders shall set the compression method to 0, and decoders shall ignore it.</p>
 
-          <p>The language tag defined in [[BCP47]] indicates the human language used by the translated keyword and the text. Unlike
-          the keyword, the language tag is case-insensitive. It is an ISO 646.IRV:1991 [[ISO646]] string consisting of
-          hyphen-separated words of 1-8 alphanumeric characters each (for example cn, en-uk, no-bok, x-klingon, x-KlInGoN). If the
-          first word is two or three letters long, it is an ISO language code [[BCP47]]. If the language tag is empty, the language
-          is unspecified.</p>
+          <p>The language tag is a well-formed language tag defined by [[BCP47]]. Unlike the keyword, the language tag is
+          case-insensitive. Subtags must appear in the IANA language subtag registry. If the language tag is empty, the language is
+          unspecified. Examples of language tags include: <code>en</code>, <code>en-GB</code>, <code>es-419</code>,
+          <code>zh-Hans</code>, <code>zh-Hans-CN</code>, <code>tlh-Cyrl-AQ</code>, <code>ar-AE-u-nu-latn</code>, and
+          <code>x-private</code>.</p>
 
           <p>The translated keyword and text both use the UTF-8 encoding [[rfc3629]], and neither shall contain a zero byte (null
           character). The text, unlike other textual data in this chunk, is not null-terminated; its length is derived from the

--- a/index.html
+++ b/index.html
@@ -3867,7 +3867,7 @@ with these exceptions:
             <tr>
               <th>Name</th>
               <th>Size</th>
-              <th>Physical units</th>
+              <th>Divisor value</th>
             </tr>
 
             <tr>
@@ -3902,10 +3902,8 @@ with these exceptions:
             corresponds to RGB order.
           </aside>
 
-          <aside class="note">
-            The physical units act as a divisor. For example, the unitless value of 0.00002 for the primaries and white point would
-            store the chromaticity (0.6800, 0.3200) as {34000, 16000}.
-          </aside>
+          <p>The divisor maps from actual value to stored value. For example, the unitless divisor of 0.00002 for the primaries and
+          white point would store the chromaticity (0.6800, 0.3200) as {34000, 16000}.</p>
 
           <p>The <span class="chunk">mASt</span> chunk MUST come before the <a class="chunk" href="#11PLTE">PLTE</a> and <a class=
           "chunk" href="#11IDAT">IDAT</a> chunks.</p>
@@ -3915,7 +3913,7 @@ with these exceptions:
             <table id="mASt-chunk-primaries-example" class="numbered simple">
               <tr>
                 <th>Name</th>
-                <th>Physical units</th>
+                <th>Actual values</th>
                 <th>Stored values</th>
               </tr>
 
@@ -3958,7 +3956,7 @@ with these exceptions:
             <table id="mASt-chunk-white-point-example" class="numbered simple">
               <tr>
                 <th>Name</th>
-                <th>Physical units</th>
+                <th>Actual values</th>
                 <th>Stored values</th>
               </tr>
 
@@ -3974,7 +3972,7 @@ with these exceptions:
             Example <span class="chunk">mASt</span> chunk mastering display maximum luminance:
             <table id="mASt-chunk-max-luminance-example" class="numbered simple">
               <tr>
-                <th>Physical units</th>
+                <th>Actual value</th>
                 <th>Stored value</th>
               </tr>
 
@@ -3989,7 +3987,7 @@ with these exceptions:
             Example <span class="chunk">mASt</span> chunk mastering display minimum luminance:
             <table id="mASt-chunk-min-luminance-example" class="numbered simple">
               <tr>
-                <th>Physical units</th>
+                <th>Actual value</th>
                 <th>Stored value</th>
               </tr>
 


### PR DESCRIPTION
This commit adds the mASt chunk, which provides mastering metadata as specified by SMPTE ST 2086.

Contributes to #236.