### PR TITLE
Prefer iTXt

### DIFF
--- a/index.html
+++ b/index.html
@@ -1293,8 +1293,7 @@ with these exceptions:
       types of ancillary information provided are described in <a href="#table41"></a>.</p>
       <!-- Maintain a fragment named "table41" to preserve incoming links to it -->
 
-      <table id="table41" class="simple numbered" summary=
-      "This table lists the types of ancillary information that may be associated with an image">
+      <table id="table41" class="simple numbered">
         <caption>
           Types of ancillary information
         </caption>
@@ -1523,7 +1522,7 @@ with these exceptions:
         "chunk" href="#fdAT-chunk">fdAT</a> chunk for the second frame. (<a class="chunk" href="#11IHDR">IHDR</a> and <a class=
         "chunk" href="#11IEND">IEND</a> chunks omitted in these tables, for clarity).</p>
 
-        <table class="numbered simple" summary="sequence numbers, if the static image is also the first frame">
+        <table class="numbered simple">
           <caption>
             If the static image is also the first frame
           </caption>
@@ -1576,7 +1575,7 @@ with these exceptions:
           </tr>
         </table>
 
-        <table class="numbered simple" summary="sequence numbers, if the static image is not part of the animation">
+        <table class="numbered simple">
           <caption>
             If the static image is not part of the animation
           </caption>
@@ -1735,7 +1734,7 @@ with these exceptions:
       </figure>
       <!-- Maintain a fragment named "table51" to preserve incoming links to it -->
 
-      <table id="table51" class="numbered simple" summary="This table defines the chunk fields">
+      <table id="table51" class="numbered simple">
         <caption>
           Chunk fields
         </caption>
@@ -1812,7 +1811,7 @@ with these exceptions:
       <p>The semantics of the property bits are defined in <a href="#table52"></a>.</p>
       <!-- Maintain a fragment named "table52" to preserve incoming links to it -->
 
-      <table id="table52" class="numbered simple" summary="This table defines the semantics of the property bits">
+      <table id="table52" class="numbered simple">
         <caption>
           Semantics of property bits
         </caption>
@@ -1923,7 +1922,7 @@ with these exceptions:
       <!-- ************Page Break******************* -->
       <!-- Maintain a fragment named "table53" to preserve incoming links to it -->
 
-      <table id="table53" class="numbered simple" summary="This table lists the chunk ordering rules">
+      <table id="table53" class="numbered simple">
         <caption>
           Chunk ordering rules
         </caption>
@@ -2173,7 +2172,7 @@ with these exceptions:
       </table>
       <!-- Maintain a fragment named "table54" to preserve incoming links to it -->
 
-      <table id="table54" class="numbered simple" summary="This table lists the symbols used in lattice diagrams">
+      <table id="table54" class="numbered simple">
         <caption>
           Meaning of symbols used in lattice diagrams
         </caption>
@@ -2358,7 +2357,7 @@ with these exceptions:
       alpha channel. The PNG image types and corresponding <a>colour types</a> are listed in <a href="#table6.1"></a>.</p>
       <!-- Maintain a fragment named "table6.1" to preserve incoming links to it -->
 
-      <table id="table6.1" class="numbered simple" summary="This table lists the PNG image and colour types">
+      <table id="table6.1" class="numbered simple">
         <caption>
           PNG image types and colour types
         </caption>
@@ -2635,7 +2634,7 @@ with these exceptions:
 
       <p>Filters may use the original values of the following bytes to generate the new byte value:</p>
 
-      <table class="numbered simple" summary="This table defines the variables used in the filter types table">
+      <table class="numbered simple">
         <caption>
           Named filter bytes
         </caption>
@@ -2695,7 +2694,7 @@ with these exceptions:
       <!-- ************Page Break******************* -->
       <!-- Maintain a fragment named "9-table91" to preserve incoming links to it -->
 
-      <table id="9-table91" class="numbered simple" summary="This table lists the filter types">
+      <table id="9-table91" class="numbered simple">
         <caption>
           Filter types
         </caption>
@@ -2832,7 +2831,7 @@ with these exceptions:
 
       <p><a>Deflate</a>-compressed datastreams within PNG are stored in the <a>zlib</a> format, which has the structure:</p>
 
-      <table summary="This table gives the structure of the zlib format">
+      <table>
         <tr>
           <td>zlib compression method/flags code</td>
           <td>1 byte</td>
@@ -2952,7 +2951,7 @@ with these exceptions:
 </pre>
         <p>The <a class="chunk" href="#11IHDR">IHDR</a> chunk shall be the first chunk in the PNG datastream. It contains:</p>
 
-        <table summary="This table defines the IHDR chunk">
+        <table>
           <tr>
             <td>Width</td>
             <td>4 bytes</td>
@@ -3002,7 +3001,7 @@ with these exceptions:
         that do not compress well. The allowed combinations are defined in <a href="#table111"></a>.</p>
         <!-- Maintain a fragment named "table111" to preserve incoming links to it -->
 
-        <table id="table111" class="numbered simple" summary="This table defines the colour types">
+        <table id="table111" class="numbered simple">
           <caption>
             Allowed combinations of <a>colour type</a> and bit depth
           </caption>
@@ -3079,7 +3078,7 @@ with these exceptions:
         <p>The <span class="chunk">PLTE</span> chunk contains from 1 to 256 palette entries, each a three-byte series of the
         form:</p>
 
-        <table summary="This table defines the PLTE palette table entries">
+        <table>
           <tr>
             <td>Red</td>
             <td>1 byte</td>
@@ -3182,7 +3181,7 @@ with these exceptions:
           "chunk">tRNS</span> chunk contains: <!-- ************Page Break******************* --></p>
           <!-- ************Page Break******************* -->
 
-          <table summary="This table defines the tRNS chunk">
+          <table>
             <tr>
               <th colspan="2">
                 <a>Colour type</a> 0
@@ -3284,7 +3283,7 @@ with these exceptions:
           <!-- ************Page Break******************* -->
           <!-- ************Page Break******************* -->
 
-          <table class="numbered simple" summary="This table defines the cHRM chunk">
+          <table class="numbered simple">
             <caption>
               cHRM chunk components
             </caption>
@@ -3367,7 +3366,7 @@ with these exceptions:
 
           <p>The <span class="chunk">gAMA</span> chunk contains:</p>
 
-          <table summary="This table defines the gAMA chunk">
+          <table>
             <tr>
               <td>Image gamma</td>
               <td>4 bytes</td>
@@ -3395,7 +3394,7 @@ with these exceptions:
 </pre>
           <p>The <span class="chunk">iCCP</span> chunk contains:</p>
 
-          <table summary="This table defines the iCCP chunk">
+          <table>
             <tr>
               <td>Profile name</td>
               <td>1-79 bytes (character string)</td>
@@ -3460,7 +3459,7 @@ with these exceptions:
           <!-- ************Page Break******************* -->
           <!-- ************Page Break******************* -->
 
-          <table class="numbered simple" summary="This table defines the sBIT chunk">
+          <table class="numbered simple">
             <caption>
               sBIT chunk contents
             </caption>
@@ -3555,7 +3554,7 @@ with these exceptions:
 
           <p>The <span class="chunk">sRGB</span> chunk contains:</p>
 
-          <table class="numbered simple" summary="This table defines the sRGB chunk">
+          <table class="numbered simple">
             <caption>
               sRGB chunk contents
             </caption>
@@ -3573,7 +3572,7 @@ with these exceptions:
 
           <p>The following values are defined for rendering intent:</p>
 
-          <table class="numbered simple" summary="This table defines the values of rendering intent in the sRGB chunk">
+          <table class="numbered simple">
             <caption>
               Rendering intent values
             </caption>
@@ -3618,7 +3617,7 @@ with these exceptions:
           "chunk" href="#11gAMA">gAMA</a> chunk (and optionally a <a class="chunk" href="#11cHRM">cHRM</a> chunk) for compatibility
           with decoders that do not use the <span class="chunk">sRGB</span> chunk. Only the following values shall be used.</p>
 
-          <table class="numbered simple" summary="This table defines the gAMA and cHRM values for sRGB">
+          <table class="numbered simple">
             <caption>
               gAMA and cHRM values for sRGB
             </caption>
@@ -3842,7 +3841,7 @@ with these exceptions:
 
           <p>The following keywords are predefined and should be used where appropriate.</p>
 
-          <table class="numbered simple" summary="This table defines the keywords defined for tEXt, iTXt and zTXt chunks">
+          <table class="numbered simple">
             <caption>
               Predefined keywords
             </caption>
@@ -3960,7 +3959,7 @@ with these exceptions:
 </pre>
           <p>Each <span class="chunk">tEXt</span> chunk contains a keyword and a text string, in the format:</p>
 
-          <table summary="This table defines the tEXt chunk">
+          <table>
             <tr>
               <td>Keyword</td>
               <td>1-79 bytes (character string)</td>
@@ -4006,7 +4005,7 @@ with these exceptions:
 
           <p>A <span class="chunk">zTXt</span> chunk contains:</p>
 
-          <table summary="This table defines the zTXt chunk">
+          <table>
             <tr>
               <td>Keyword</td>
               <td>1-79 bytes (character string)</td>
@@ -4048,7 +4047,7 @@ with these exceptions:
 </pre>
           <p>An <span class="chunk">iTXt</span> chunk contains:</p>
 
-          <table summary="This table defines the iTXt chunk">
+          <table>
             <tr>
               <td>Keyword</td>
               <td>1-79 bytes (character string)</td>
@@ -4141,7 +4140,7 @@ with these exceptions:
           is any other preferred background, either user-specified or part of a larger page (as in a browser), the <span class=
           "chunk">bKGD</span> chunk should be ignored. The <span class="chunk">bKGD</span> chunk contains:</p>
 
-          <table class="numbered simple" summary="This table defines the bKGD chunk">
+          <table class="numbered simple">
             <caption>
               bKGD chunk contents
             </caption>
@@ -4204,7 +4203,7 @@ with these exceptions:
 </pre>
           <p>The <span class="chunk">hIST</span> chunk contains a series of two-byte unsigned integers:</p>
 
-          <table summary="This table defines the hIST chunk">
+          <table>
             <tr>
               <td>Frequency</td>
               <td>2 bytes (unsigned integer)</td>
@@ -4245,7 +4244,7 @@ with these exceptions:
           <p>The <span class="chunk">pHYs</span> chunk specifies the intended pixel size or aspect ratio for display of the image.
           It contains:</p>
 
-          <table class="numbered simple" summary="This table defines the pHYs chunk">
+          <table class="numbered simple">
             <caption>
               pHYs chunk contents
             </caption>
@@ -4277,7 +4276,7 @@ with these exceptions:
 
           <p>The following values are defined for the unit specifier:</p>
 
-          <table class="numbered simple" summary="This table defines the allowed values for the unit specifier in the pHYs chunk">
+          <table class="numbered simple">
             <caption>
               Unit specifier values
             </caption>
@@ -4316,7 +4315,7 @@ with these exceptions:
 </pre>
           <p>The <span class="chunk">sPLT</span> chunk contains:</p>
 
-          <table class="numbered simple" summary="This table defines the sPLT chunk">
+          <table class="numbered simple">
             <caption>
               sPLT chunk contents
             </caption>
@@ -4487,7 +4486,7 @@ with these exceptions:
           <p>The <span class="chunk">tIME</span> chunk gives the time of the last image modification (<strong>not</strong> the time
           of initial image creation). It contains:</p>
 
-          <table class="numbered simple" summary="This table defines the tIME chunk">
+          <table class="numbered simple">
             <caption>
               tIME chunk contents
             </caption>
@@ -4549,7 +4548,7 @@ with these exceptions:
           <p>The <span class="chunk">acTL</span> chunk declares that this is an animated PNG image, gives the number of frames, and
           the number of times to loop. It contains:</p>
 
-          <table summary="This table defines the acTL chunk">
+          <table>
             <tr>
               <td>`num_frames`</td>
               <td>4 bytes</td>
@@ -4588,7 +4587,7 @@ with these exceptions:
           <p>The <span class="chunk">fcTL</span> chunk defines the dimensions, position, delay and disposal of an individual frame.
           Exactly one <span class="chunk">fcTL</span> chunk chunk is required for each frame. It contains:</p>
 
-          <table class="numbered simple" summary="This table defines the fcTL chunk">
+          <table class="numbered simple">
             <caption>
               fcTL chunk contents
             </caption>
@@ -4673,7 +4672,7 @@ with these exceptions:
 
           <p>Valid values for `dispose_op` are:</p>
 
-          <table summary="This table defines the disposal operators">
+          <table>
             <tr>
               <td>0</td>
               <td>`APNG_DISPOSE_OP_NONE`</td>
@@ -4714,7 +4713,7 @@ with these exceptions:
 
           <p>Valid values for `blend_op` are:</p>
 
-          <table summary="This table defines the blend operators">
+          <table>
             <tr>
               <td>0</td>
               <td>`APNG_BLEND_OP_SOURCE`</td>
@@ -4776,7 +4775,7 @@ with these exceptions:
           "#11IDAT">IDAT</a> chunk does for static images; it contains the <a>image data</a> for all frames (or, for animations
           which include the <a>static image</a> as first frame, for all frames after the first one). It contains:</p>
 
-          <table class="numbered simple" summary="This table defines the fdAT chunk">
+          <table class="numbered simple">
             <caption>
               fdAT chunk contents
             </caption>
@@ -5019,7 +5018,7 @@ cHRM</a> chunk.</p>-->
       <!-- ************Page Break******************* -->
       <!-- Maintain a fragment named "12-table121" to preserve incoming links to it -->
 
-      <table id="12-table121" class="numbered simple" summary="CCIR 709 primaries and D65 whitepoint">
+      <table id="12-table121" class="numbered simple">
         <caption>
           CCIR 709 primaries and D65 whitepoint
         </caption>
@@ -5052,7 +5051,7 @@ cHRM</a> chunk.</p>-->
       <p>An older but still very popular video standard is SMPTE-C [[SMPTE 170M]] given in <a href="#12-table122"></a>.</p>
       <!-- Maintain a fragment named "12-table122" to preserve incoming links to it -->
 
-      <table id="12-table122" class="numbered simple" summary="CSMPTE-C video standard">
+      <table id="12-table122" class="numbered simple">
         <caption>
           SMPTE-C video standard
         </caption>
@@ -6761,10 +6760,8 @@ will need to be replaced by copies of lines 17-23, but processing background ins
           <dd>None</dd>
     
           <dt>Published specification:</dt>
-          <dd><a href="https://www.w3.org/TR/png/
-            ">Portable Network Graphics (PNG) Specification</a>,
-            <a href="https://www.w3.org/TR/png/
-            ">https://www.w3.org/TR/png/</a>
+          <dd><a href="https://www.w3.org/TR/png/">Portable Network Graphics (PNG) Specification</a>,
+            <a href="https://www.w3.org/TR/png/">https://www.w3.org/TR/png/</a>
           </dd>
     
           <dt>Applications which use this media:</dt>
@@ -6884,7 +6881,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
     non-linear <a>transfer functions</a> may occur and which may be modelled by power laws. The characteristic exponent associated
     with each is given a specific name.</p>
 
-    <table summary="This table describes characteristic exponents">
+    <table>
       <tr>
         <td><var>input_exponent</var>
         </td>
@@ -6928,7 +6925,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
     <p>It is convenient to define some additional entities that describe some composite <a>transfer functions</a>, or combinations
     of stages.</p>
 
-    <table summary="This table characterises additional entities that are used to describe transfer functions">
+    <table>
       <tr>
         <td><var>display_exponent</var>
         </td>
@@ -6982,7 +6979,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
     users to read the code more easily.</p>
     <!-- Maintain a fragment named "D-tabled1" to preserve incoming links to it -->
 
-    <table id="D-tabled1" class="numbered simple" summary="This table gives hints for reading the CRC code">
+    <table id="D-tabled1" class="numbered simple">
       <caption>
         Hints for reading ISO C code
       </caption>

--- a/index.html
+++ b/index.html
@@ -6805,6 +6805,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
               brings official documentation into alignment with already 
               widely-deployed reality. 
           </p>
+          </dd>
     
           <dt>Person to contact for further information:</dt>
           <dd>

--- a/index.html
+++ b/index.html
@@ -3936,12 +3936,16 @@ with these exceptions:
           <p>For the Creation Time keyword, the date format defined in section&#160;5.2.14 of RFC 1123 is suggested, but not
           required [[rfc1123]].</p>
 
-          <p>In the <a class="chunk" href="#11tEXt">tEXt</a> and <a class="chunk" href="#11zTXt">zTXt</a> chunks, the text string
-          associated with a keyword is restricted to the Latin-1 character set plus the linefeed character. Text strings in
-          <a class="chunk" href="#11zTXt">zTXt</a> are compressed into <a>zlib</a> datastreams using <a>deflate</a> compression
-          (see <a href='#10CompressionOtherUses'></a>). The <a class="chunk" href="#11iTXt">iTXt</a> chunk can be used to convey
-          characters outside the Latin-1 set. It uses the UTF-8 encoding [[rfc3629]]. There is an option to compress text strings
-          in the <a class="chunk" href="#11iTXt">iTXt</a> chunk.</p>
+          <p>The <a class="chunk" href="#11iTXt">iTXt</a> chunk uses the UTF-8 encoding [[rfc3629]] and 
+            can be used to convey characters in any language. 
+            There is an option to compress text strings
+            in the <a class="chunk" href="#11iTXt">iTXt</a> chunk.
+            <a class="chunk" href="#11iTXt">iTXt</a> is recommended for all text strings, as it supports Unicode.
+            There are also <a class="chunk" href="#11tEXt">tEXt</a> and <a class="chunk" href="#11zTXt">zTXt</a> chunks,
+            whose content is restricted to the printable Latin-1 character set plus U+000A LINE FEED (LF).
+            Text strings in <a class="chunk" href="#11zTXt">zTXt</a> are compressed into <a>zlib</a> datastreams 
+            using <a>deflate</a> compression (see <a href='#10CompressionOtherUses'></a>).  </p>
+
         </section>
         <!-- Maintain a fragment named "11tEXt" to preserve incoming links to it -->
 

--- a/index.html
+++ b/index.html
@@ -266,8 +266,6 @@ with these exceptions:
 
   <h2 id="Introduction">Introduction</h2>
 
-  <p>
-  </p>
 
   <p>The design goals for this specification were:</p>
 
@@ -2515,8 +2513,6 @@ with these exceptions:
       <p>A <dfn id="3filter">filter method</dfn> is a transformation applied to an array of <a>scanlines</a> with the aim of
       improving their compressibility.</p>
 
-      <p>
-      </p>
 
       <p>PNG standardizes one <a>filter method</a> and several filter types that may be used to prepare <a>image data</a> for
       compression. It transforms the byte sequence into an equal length sequence of bytes preceded by a filter type byte (see
@@ -2707,7 +2703,7 @@ with these exceptions:
         </tr>
 
         <tr>
-          <td align="center">0</td>
+          <td>0</td>
           <td>None</td>
           <td><code>Filt(x) = Orig(x)</code>
           </td>
@@ -2716,7 +2712,7 @@ with these exceptions:
         </tr>
 
         <tr>
-          <td align="center">1</td>
+          <td>1</td>
           <td>Sub</td>
           <td><code>Filt(x) = Orig(x) - Orig(a)</code>
           </td>
@@ -2725,7 +2721,7 @@ with these exceptions:
         </tr>
 
         <tr>
-          <td align="center">2</td>
+          <td>2</td>
           <td>Up</td>
           <td><code>Filt(x) = Orig(x) - Orig(b)</code>
           </td>
@@ -2734,7 +2730,7 @@ with these exceptions:
         </tr>
 
         <tr>
-          <td align="center">3</td>
+          <td>3</td>
           <td>Average</td>
           <td><code>Filt(x) = Orig(x) - floor((Orig(a) + Orig(b)) / 2)</code>
           </td>
@@ -2743,7 +2739,7 @@ with these exceptions:
         </tr>
 
         <tr>
-          <td align="center">4</td>
+          <td>4</td>
           <td>Paeth</td>
           <td><code>Filt(x) = Orig(x) - PaethPredictor(Orig(a), Orig(b), Orig(c))</code>
           </td>
@@ -3015,21 +3011,21 @@ with these exceptions:
 
           <tr>
             <td>Greyscale</td>
-            <td align="center">0</td>
+            <td>0</td>
             <td>1, 2, 4, 8, 16</td>
             <td>Each pixel is a greyscale sample</td>
           </tr>
 
           <tr>
             <td>Truecolour</td>
-            <td align="center">2</td>
+            <td>2</td>
             <td>8, 16</td>
             <td>Each pixel is an R,G,B triple</td>
           </tr>
 
           <tr>
             <td>Indexed-colour</td>
-            <td align="center">3</td>
+            <td>3</td>
             <td>1, 2, 4, 8</td>
             <td>
               Each pixel is a palette index; a <a class="chunk" href="#11PLTE">PLTE</a> chunk shall appear.
@@ -3038,14 +3034,14 @@ with these exceptions:
 
           <tr>
             <td>Greyscale with alpha</td>
-            <td align="center">4</td>
+            <td>4</td>
             <td>8, 16</td>
             <td>Each pixel is a greyscale sample followed by an alpha sample.</td>
           </tr>
 
           <tr>
             <td>Truecolour with alpha</td>
-            <td align="center">6</td>
+            <td>6</td>
             <td>8, 16</td>
             <td>Each pixel is an R,G,B triple followed by an alpha sample.</td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
       wgURI: "https://www.w3.org/groups/wg/png",
       wgPublicList: "public-png",
       wgPatentURI: "https://www.w3.org/groups/wg/png/ipr",
+      xref: ["i18n-glossary"],
       localBiblio: {
         "CIPA DC-008": {
           title: "Exchangeable image file format for digital still cameras: Exif Version 2.32",
@@ -5311,16 +5312,22 @@ output = floor((input * MAXOUTSAMPLE / MAXINSAMPLE) + 0.5)
       description of the text is available. If a user-supplied keyword is used, encoders should check that it meets the
       restrictions on keywords.</p>
 
-      <p>For the <a class="chunk" href="#11tEXt">tEXt</a> and <a class="chunk" href="#11zTXt">zTXt</a> chunks, PNG text strings are
-      expected to use the Latin-1 character set. Encoders should avoid storing characters that are not defined in Latin-1, and
-      should provide character code remapping if the local system's character set is not Latin-1. The <a class="chunk" href=
-      "#11iTXt">iTXt</a> chunk provides support for international text, represented using the UTF-8 encoding of UCS. Encoders
-      should discourage the creation of single lines of text longer than 79 characters, in order to facilitate easy reading. It is
-      recommended that text items less than 1024 bytes in size should be output using uncompressed text chunks. It is recommended
-      that the basic title and author keywords be output using uncompressed text chunks. Placing large text chunks after the
-      <a>image data</a> (after the <a class="chunk" href="#11IDAT">IDAT</a> chunks) can speed up image display in some situations,
+      <p>The <a class="chunk" href="#11iTXt">iTXt</a> chunk uses the UTF-8 encoding of Unicode 
+      and thus can store text in any language. The <a class="chunk" href="#11tEXt">tEXt</a> and <a class="chunk" href="#11zTXt">zTXt</a> chunks use the Latin-1 (ISO 8859-1) character encoding, 
+      which limits the range of characters that can be used in these chunks. 
+      Encoders should prefer <a class="chunk" href="#11iTXt">iTXt</a> to 
+      <a class="chunk" href="#11tEXt">tEXt</a> and <a class="chunk" href="#11zTXt">zTXt</a> chunks.
+      in order to allow a wide range of characters without data loss. 
+      Encoders must convert characters that use local <a>legacy character encodings</a>
+      to the appropriate encoding when storing text.
+      Encoders should discourage the creation of single lines of text longer than 79 Unicode <a>code points</a>, 
+      in order to facilitate easy reading. 
+      It is recommended that text items less than 1024 bytes in size should be output using uncompressed text chunks. 
+      It is recommended that the basic title and author keywords be output using uncompressed text chunks. 
+      Placing large text chunks after the <a>image data</a> (after the <a class="chunk" href="#11IDAT">IDAT</a> chunks) can speed up image display in some situations,
       as the decoder will decode the <a>image data</a> first. It is recommended that small text chunks, such as the image title,
       appear before the <a class="chunk" href="#11IDAT">IDAT</a> chunks.</p>
+
     </section>
     <!-- ************Page Break******************* -->
     <!-- ************Page Break******************* -->


### PR DESCRIPTION
Corrects both paragraphs per @aphillips suggestions. Adds links to I18n glossary.

ReSpec complains about these being normative.