### PR TITLE
Use 203 cd/m^2 instead of 200

### DIFF
--- a/index.html
+++ b/index.html
@@ -4076,7 +4076,7 @@ with these exceptions:
 
           <aside class="example">
             Example <span class="chunk">mDCv</span> chunk mastering display maximum 
-            luminance using "single-master" SDR shading techniques at 200 cd/m<sup>2</sup> 
+            luminance using "single-master" SDR shading techniques at 203 cd/m<sup>2</sup> 
             (described in ITU-R BT.2408 Annex Y):
             <table id="mDCv-chunk-max-luminance-example" class="numbered simple">
               <tr>
@@ -4085,8 +4085,8 @@ with these exceptions:
               </tr>
 
               <tr>
-                <td>200 cd/m<sup>2</sup></td>
-                <td>2000000</td>
+                <td>203 cd/m<sup>2</sup></td>
+                <td>2030000</td>
               </tr>
             </table>
           </aside>


### PR DESCRIPTION
ITU BT.2408-6 suggests 203 cd/m^2, not 200.
This commit updates our example to use 203 cd/m^2.