### PR TITLE
Simplify Scope section

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,12 +343,7 @@ with these exceptions:
 
     <p>This specification specifies a datastream and an associated file format, Portable Network Graphics (PNG, pronounced "ping"),
     for a <a>lossless</a>, portable, compressed individual computer graphics image or frame-based animation, transmitted across the
-    Internet. Indexed-colour, greyscale, and <a>truecolour</a> images are supported, with optional transparency. Sample depths
-    range from 1 to 16 bits. PNG is fully streamable with a progressive display option. It is robust, providing both full file
-    integrity checking and simple detection of common transmission errors. PNG can store <a>gamma value</a> and chromaticity data
-    as well as a full ICC colour profile, CICP image format signaling metadata, and mastering metadata (mDCv and mLUm) for 
-    accurate colour matching on heterogeneous platforms. This Standard defines the Internet Media types "image/png" and "image/apng". 
-    The datastream and associated file format have value outside of the main design goal.</p>
+    Internet.
   </section>
 
   <section>


### PR DESCRIPTION
Currently, the Scope section goes into details beyond the scope. These details are described elsewhere. They don't really belong (nor are they needed) in the Scope section.

This commit follows the suggestion from @palemieux to remove this extra information from the Scope section.

Closes #269