### PR TITLE
Silence informative link warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
       wgURI: "https://www.w3.org/groups/wg/png",
       wgPublicList: "public-png",
       wgPatentURI: "https://www.w3.org/groups/wg/png/ipr",
+      lint: { "informative-dfn": false },
       xref: ["i18n-glossary"],
       localBiblio: {
         "CIPA DC-008": {


### PR DESCRIPTION
There are currently 3 links which are treated as normative references. However, the i18n-glossary defined the terms informatively since it is only a note. This causes a lint warning.

@svgeesus looked into it and found the correct path forward is a blanket silence on that linter step. In fact, it sounds like this check was moved to the linter so it could be silenced.

This commit silences the linter for these informative/normative mismatches.

Closes #270 