### PR TITLE
Fix broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -7513,7 +7513,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
       <!-- to 6 March 2023 -->
       <li>Corrected error in <a href="#eXIf" class="chunk">eXIf</a> chunk, 
         which conflicted with the <a href="#5ChunkOrdering">chunk ordering</a> section.</li>
-      <li>Simplified <a href="l#1Scope">Scope</a> section to remove redundant detail described elsewhere.</li>
+      <li>Simplified <a href="#1Scope">Scope</a> section to remove redundant detail described elsewhere.</li>
       <li>Redrew chunk-ordering lattice diagrams to be clearer and more consistent.</li>
       <li>Added new chunk, <a href="#mLUm-chunk" class="chunk">mLUm</a>, 
       to describe the Maximum Single-Pixel and Frame-Average Luminance Levels


### PR DESCRIPTION
There is a typo in a link. This commit fixes it.