### PR TITLE
Update cLLI values

### DIFF
--- a/index.html
+++ b/index.html
@@ -3906,7 +3906,7 @@ with these exceptions:
           <p>The four-byte chunk type field contains the hexadecimal values</p>
 
           <pre>
-<!-- 109 76 85 109 -->6D 4C 55 6D
+<!-- 99 76 76 105 -->63 4C 4C 69
 </pre>
         
           <p>If present, the <span class="chunk">cLLi</span> chunk identifies two characteristics:</p>


### PR DESCRIPTION
When the mLUm chunk was renamed to cLLI, the ASCII values for it were not updated.

This commit updates those values.