### PR TITLE
Update units representation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3916,7 +3916,7 @@ with these exceptions:
              calculated by averaging the decoded luminance values of all the pixels within a frame.</p>
              
           <p>MaxCLL (Maximum Content Light Level) indicates the maximum light level of any single 
-             pixel (in cd/m2 or nits) of the entire playback sequence.  There is often an algorithmic 
+             pixel (in cd/m<sup>2</sup>, also known as nits) of the entire playback sequence.  There is often an algorithmic 
              filter to eliminate false values occurring from processing or noise that could adversely 
              affect intended downstream tone mapping</p>
   

--- a/index.html
+++ b/index.html
@@ -3912,7 +3912,7 @@ with these exceptions:
           <p>If present, the <span class="chunk">cLLi</span> chunk identifies two characteristics:</p>
              
           <p>MaxFALL (Maximum Frame Average Light Level) indicates the maximum value of the frame 
-             average light level (in cd/m2 or nits) of the entire playback sequence. MaxFALL is 
+             average light level (in cd/m<sup>2</sup>, also known as nits) of the entire playback sequence. MaxFALL is 
              calculated by averaging the decoded luminance values of all the pixels within a frame.</p>
              
           <p>MaxCLL (Maximum Content Light Level) indicates the maximum light level of any single 


### PR DESCRIPTION
There is wording of "cd/m2", which doesn't have the 2 raised like it should be. Additionally, the wording says "or nits" which may be confusing.

This commit changes that wording to be more accurate and hopefully also more clear.