### PR TITLE
Correct hyphenation and link to reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -3687,7 +3687,7 @@ with these exceptions:
           for both HDR and SDR are available in [[ITU-T Series H Supplement 19]].</p>
 
           <p> For SDR images, if MDCV display min/max luminance are unknown, the default 
-          characteristics can be derived from the values in ITU_T Series H Supplemental 19 Table 11 .”</p>
+          characteristics can be derived from the values in [[ITU-T Series H Supplemental 19]] Table 11 .”</p>
 
           <p>The following specifies the syntax of the <span class="chunk">mDCv</span> chunk:</p>
 


### PR DESCRIPTION
Previously, a reference was named with "ITU_T Series H...". But that should have been "ITU-T Series H...".

This commit corrects the hyphenation. Additionally, it links to the reference.