### PR TITLE
Correct typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -3586,7 +3586,7 @@ with these exceptions:
           <p>The <code>Matrix Coefficients</code> value is equal to <code>0</code>.</p>
 
           <aside class="note">
-            A <code>Matrix Coefficients</code> value othen than <code>0</code> signals a transformation between colour difference
+            A <code>Matrix Coefficients</code> value other than <code>0</code> signals a transformation between colour difference
             and RGB representations, which is not used in this International Standard since PNG images are RGB images.
           </aside>
 


### PR DESCRIPTION
Currently, there is a typo: "othen". It is supposed to be "other".

This commit corrects that typo.

Closes #296