### PR TITLE
Fix broken reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -3688,7 +3688,7 @@ with these exceptions:
           for both HDR and SDR are available in [[ITU-T Series H Supplement 19]].</p>
 
           <p> For SDR images, if mDCv display min/max luminance are unknown, the default 
-          characteristics can be derived from the values in [[ITU-T Series H Supplemental 19]] Table 11 .”</p>
+          characteristics can be derived from the values in [[ITU-T Series H Supplement 19]] Table 11 .”</p>
 
           <p>The following specifies the syntax of the <span class="chunk">mDCv</span> chunk:</p>
 


### PR DESCRIPTION
A reference was added with "Supplemental" in the title, when it should have been "Supplement". This cause the reference to not be found.

This commit fixes that broken reference.
Closes #299