### PR TITLE
Change mLUm to cLLi

### DIFF
--- a/figures/lattice-diagram-apng-static-first-with-plte.svg
+++ b/figures/lattice-diagram-apng-static-first-with-plte.svg
@@ -123,7 +123,7 @@
 </g>
 <g transform="translate(755,0)">
 <rect width="55" height="40" />
-<text x="5" y="25">mLUm</text>
+<text x="5" y="25">cLLi</text>
 <text x="45" y="12" style="font-size:8pt">?</text>
 </g>
 </g>

--- a/figures/lattice-diagram-apng-static-first-without-plte.svg
+++ b/figures/lattice-diagram-apng-static-first-without-plte.svg
@@ -107,7 +107,7 @@
 
 <g transform="translate(740,0)">
 <rect width="50" height="40" />
-<text x="5" y="25">mLUm</text>
+<text x="5" y="25">cLLi</text>
 <text x="40" y="12" style="font-size:8pt">?</text>
 </g>
 

--- a/figures/lattice-diagram-apng-static-notfirst-with-plte.svg
+++ b/figures/lattice-diagram-apng-static-notfirst-with-plte.svg
@@ -119,7 +119,7 @@
 </g>
 <g transform="translate(755,0)">
 <rect width="55" height="40" />
-<text x="5" y="25">mLUm</text>
+<text x="5" y="25">cLLi</text>
 <text x="45" y="12" style="font-size:8pt">?</text>
 </g>
 </g>

--- a/figures/lattice-diagram-apng-static-notfirst-without-plte.svg
+++ b/figures/lattice-diagram-apng-static-notfirst-without-plte.svg
@@ -107,7 +107,7 @@
 
 <g transform="translate(740,0)">
 <rect width="50" height="40" />
-<text x="5" y="25">mLUm</text>
+<text x="5" y="25">cLLi</text>
 <text x="40" y="12" style="font-size:8pt">?</text>
 </g>
 

--- a/figures/lattice-diagram-with-plte.svg
+++ b/figures/lattice-diagram-with-plte.svg
@@ -119,7 +119,7 @@
 </g>
 <g transform="translate(755,0)">
 <rect width="55" height="40" />
-<text x="5" y="25">mLUm</text>
+<text x="5" y="25">cLLi</text>
 <text x="45" y="12" style="font-size:8pt">?</text>
 </g>
 </g>

--- a/figures/lattice-diagram-without-plte.svg
+++ b/figures/lattice-diagram-without-plte.svg
@@ -107,7 +107,7 @@
 
 <g transform="translate(740,0)">
 <rect width="50" height="40" />
-<text x="5" y="25">mLUm</text>
+<text x="5" y="25">cLLi</text>
 <text x="40" y="12" style="font-size:8pt">?</text>
 </g>
 


### PR DESCRIPTION
The lattice diagrams still had the old `mLUm` chunk name; changed to `cLLi`.