### PR TITLE
Addressing #341 #342 and #343 

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,9 +16,9 @@
       group: "png",
       specStatus: "WD",
       shortName: "png-3",
-      publishDate: "2023-07-20",
+      publishDate: "2023-08-15",
       copyrightStart: "1996",
-      previousPublishDate: "2022-10-25",
+      previousPublishDate: "2022-07-20",
       previousMaturity: "FPWD",
       edDraftURI: "https://w3c.github.io/PNG-spec/",
       github: {
@@ -3627,12 +3627,12 @@ with these exceptions:
             images</a>. If <code>Video Full Range Flag</code> value is <code>0</code>, then the image is a <a>narrow-range
             image</a>. Narrow range images are found in video workflows where the interpretation of sample values below reference
             black (0% signal level) or above nominal peak (100% signal level). For example, [[ITU-R-BT.709]] specifies that, for
-            10-bit coding, reference black (called black level) corresponds to code value 64 and nominal peak to code value 940. In
-            narrow range, momentary excursions defined as overshoots and undershoots exist below reference black and above nominal
-            peak in uncontrolled lighting conditions, in order to preserve processing artifacts caused by video
-            filtering/compression without clipping which can improve image quality during additional stages of processing and
-            compression. The use of undershoot/overshoot has also been used to preserve additional color volume (both light and
-            color) as described in [[EBU-R-103]]. [[SMPTE-RP-2077]] describes full range in more detail and includes the mapping
+            10-bit coding, reference black (called black level) corresponds to code value 64 and nominal peak to code value 940. 
+            In narrow range, momentary excursions defined as overshoots and undershoots exist below reference black and above nominal 
+            peak in order to preserve processing artifacts caused by filtering/compression or by uncontrolled lighting without 
+            clipping.  This can improve image quality during additional stages of processing and compression. The use of 
+            undershoot/overshoot has also been used to preserve additional color volume (both light and color) as described in 
+            [[EBU-R-103]]. [[SMPTE-RP-2077]] describes full range in more detail and includes the mapping
             from <a>full-range images</a> to <a>narrow-range images</a> and describes protected code values for SDI (baseband)
             carriage.
           </aside>

--- a/index.html
+++ b/index.html
@@ -461,6 +461,20 @@ with these exceptions:
       <dd>
         power-law <a>transfer function</a>
       </dd>
+        
+      <dt id="3pq"><dfn>high dynamic range (HDR)</dfn>
+      </dt>
+
+      <dd>
+        an image format capable of storing images with a relatively low dynamic range of 5-8 stops. Examples include sRGB, Display P3, ITU-R BT.709
+      </dd>
+        
+      <dt id="3hlg"><dfn>hybrid log-gamma (HLG)</dfn>
+      </dt>
+
+      <dd>
+        <a>transfer function</a> defined in ITU-R BT.2100 Table 5. (A relative scene-referred system)
+      </dd>
 
       <dt><dfn>full-range image</dfn>
       </dt>
@@ -524,6 +538,13 @@ with these exceptions:
         significance (MSB LSB for two-byte integers, MSB B2 B1 LSB for four-byte integers)
       </dd>
 
+      <dt id="3pq"><dfn>perceptual quantiser (PQ)</dfn>
+      </dt>
+
+      <dd>
+        <a>transfer function</a> defined in ITU-R BT.2100 Table 4. N.B. only RGB may be used in PNG, ICtCp is NOT supported. (An absolute display-referred system)
+      </dd>
+        
       <!-- ************Page Break******************* -->
       <!-- ************Page Break******************* -->
       <!-- Maintain a fragment named "3PNGdecoder" to preserve incoming links to it -->
@@ -593,6 +614,20 @@ with these exceptions:
 
       <dd>
         row of <a>pixels</a> within an image or <a>interlaced PNG image</a>.
+      </dd>
+        
+      <dt id="3sdr"><dfn>standard dynamic range (SDR)</dfn>
+      </dt>
+
+      <dd>
+        an image format capable of storing images with a relatively high dynamic range similar to or in excess of the human visual system's instantaneous dynamic range (~12-14 stops). PNG allows the use of 2 HDR formats, HLG and PQ.
+      </dd>
+      
+        <dt id="3stop"><dfn>stop</dfn>
+      </dt>
+
+      <dd>
+        a change in scene light luminance of a factor of 2.
       </dd>
 
       <dt><dfn>transfer function</dfn>

--- a/index.html
+++ b/index.html
@@ -3746,16 +3746,16 @@ with these exceptions:
           the Mastering Display Color Volume (mDCv) used at the point of content creation, 
           as specified in [[SMPTE-ST-2086]]. The mDCv provides informative static metadata to 
           allow a destination (consumer) display to optimize it's tone and color mappings based 
-          on its inherent capabilities. The mDCv chunk should be included for both PQ and SDR 
-          images. It is less common for HLG images. Color Primaries and White Point characteristics 
-          can be derived from cICP chunk formats. Specific examples of its most common use-cases 
-          for both HDR and SDR are available in [[ITU-T-Series-H-Supplement-19]].</p>
+          on its inherent capabilities. The mDCv chunk should be included for PQ 
+          images. It is less common for other image formats but may be included. Color Primaries and White Point characteristics 
+          can be derived from cICP chunk formats. Specific examples of common use-cases 
+          for ITU formats are available in [[ITU-T-Series-H-Supplement-19]].</p>
 
           <p class="note"><a href="https://github.com/w3c/PNG-spec/issues/319">Issue #319</a> discusses tone-mapping behavior when
           the <span class="chunk">mDCv</span> chunk is present.</p>
 
-          <p> For SDR images, if mDCv display min/max luminance are unknown, the default 
-          characteristics can be derived from the values in [[ITU-T-Series-H-Supplement-19]] Table 11 .”</p>
+          <p> If mDCv display min/max luminance are unknown, the default 
+          characteristics can be derived from the values given in the image format specification or, for ITU formats, from [[ITU-T-Series-H-Supplement-19]] Table 11 .”</p>
 
           <p>The following specifies the syntax of the <span class="chunk">mDCv</span> chunk:</p>
 
@@ -3934,7 +3934,7 @@ with these exceptions:
 
           <aside class="example">
             Example <span class="chunk">mDCv</span> chunk mastering display maximum 
-            luminance using traditional SDR shading techniques at 100 cd/m<sup>2</sup> 
+            luminance using traditional live television production techniques at 100 cd/m<sup>2</sup> 
             (described in [[ITU-R-BT.2035]]):
             <table id="mDCv-chunk-max-luminance-example3" class="numbered simple">
               <tr>
@@ -3951,7 +3951,7 @@ with these exceptions:
 
           <aside class="example">
             Example <span class="chunk">mDCv</span> chunk mastering display maximum 
-            luminance using "single-master" SDR shading techniques at 203 cd/m<sup>2</sup> 
+            luminance using "single-master" live television production techniques at 203 cd/m<sup>2</sup> 
             (described in ITU-R BT.2408 Annex Y):
             <table id="mDCv-chunk-max-luminance-example4" class="numbered simple">
               <tr>
@@ -3993,7 +3993,8 @@ with these exceptions:
 
           <p>Each <a>frame</a> is analyzed.</p>
 
-          <p>A value of zero for either MaxCLL or MaxFALL means that the value is unknown.</p>
+          <p>A value of zero for either MaxCLL or MaxFALL means that the value is unknown or not currently caclulable.</p>
+            
  
 
            <p>The following specifies the syntax of the <span class="chunk">cLLi</span> chunk:</p>

--- a/index.html
+++ b/index.html
@@ -3993,9 +3993,9 @@ with these exceptions:
 
           <p>Each <a>frame</a> is analyzed.</p>
 
-          <p>A value of zero for either MaxCLL or MaxFALL means that the value is unknown or not currently caclulable.</p>
+          <p>A value of zero for either MaxCLL or MaxFALL means that the value is unknown or not currently calculable.</p>
             
- 
+          <p class="note">An example where this will not be calculable is when creating a live animated PNG stream, when not all frames will be available to compute the values until the stream ends.  The encoder may wish to use the value zero initially and replace this with the calculated value when the stream ends.</p>
 
            <p>The following specifies the syntax of the <span class="chunk">cLLi</span> chunk:</p>
 

--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
         { name: "Paul Schmidt" },
         { name: "Andrew Smith" },
         { name: "Michael Stokes" },
+        { name: "Simon Thompson", company: "British Broadcasting Corporation", companyURL: "https://www.bbc.co.uk" },
         { name: "Vladimir Vukicevic" },
         { name: "Tim Wegner" },
         { name: "Jeremy Wohl" }

--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
           title: "Series H: Audio Visual and Multimedia Systems - Usage of video signal type code points",
           publisher: "ITU",
           date: "2021-04",
-          href: "https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=13895"
+          href: "https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=14652"
         },
         "MovieLabs-Recommended-Best-Practice-for-SDR-to-HDR-Conversion": {
             title: "MovieLabs Best Practices for Mapping BT.709 Content to HDR10 for Consumer Distribution",


### PR DESCRIPTION
- Added definitions of HDR, SDR, PQ, HLG and stop
- Updated text about narrow range image formats
- Updated removing TV specific terminology
- Fixed ITU-T Supplement 19 link
- Added note about calculation of MaxFALL and MaxCLL for animated PNG

Once we're happy with the text, still need to:
- Link to definitions from main text