### PR TITLE
Fix definitions and add links to defined terms

### DIFF
--- a/index.html
+++ b/index.html
@@ -625,7 +625,7 @@ with these exceptions:
 
       <dd>
         an image format capable of storing images with a relatively low dynamic range of 5-8 <a>stops</a>. Examples include sRGB, Display P3, ITU-R BT.709
-      <p class="note">Standard dynamic range is independent of the primaries and hence, gamut.  Wide color gamur <a>SDR</a> formats are supported by PNG.</p></dd>
+      <p class="note">Standard dynamic range is independent of the primaries and hence, gamut. Wide color gamut <a>SDR</a> formats are supported by PNG.</p></dd>
 
       <dt><dfn>stop</dfn>
       </dt>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       group: "png",
       specStatus: "WD",
       shortName: "png-3",
-      publishDate: "2023-08-15",
+      publishDate: "2023-08-17",
       copyrightStart: "1996",
       previousPublishDate: "2022-07-20",
       previousMaturity: "FPWD",
@@ -421,10 +421,10 @@ with these exceptions:
 
       <dt><dfn>frame</dfn></dt>
 
-      <dd>For static PNG, the <a>static image</a> 
-        is considered to be the first (and only) frame. 
-        For animated PNG, each image that forms part  
-        of the <a href="#apng-frame-based-animation">frame-based animation</a> sequence 
+      <dd>For static PNG, the <a>static image</a>
+        is considered to be the first (and only) frame.
+        For animated PNG, each image that forms part
+        of the <a href="#apng-frame-based-animation">frame-based animation</a> sequence
         is a frame.
         Thus, for animated PNG, when the static image is not the first frame,
         the static image is not considered to be a frame.
@@ -461,15 +461,15 @@ with these exceptions:
       <dd>
         power-law <a>transfer function</a>
       </dd>
-        
-      <dt id="3pq"><dfn>high dynamic range (HDR)</dfn>
+
+      <dt>high dynamic range (<dfn>HDR</dfn>)
       </dt>
 
       <dd>
-        an image format capable of storing images with a relatively low dynamic range of 5-8 stops. Examples include sRGB, Display P3, ITU-R BT.709
+        an image format capable of storing images with a relatively high dynamic range similar to or in excess of the human visual system's instantaneous dynamic range (~12-14 <a>stops</a>). PNG allows the use of two <a>HDR</a> formats, <a>HLG</a> and <a>PQ</a>.
       </dd>
-        
-      <dt id="3hlg"><dfn>hybrid log-gamma (HLG)</dfn>
+
+      <dt>hybrid log-gamma (<dfn>HLG</dfn>)
       </dt>
 
       <dd>
@@ -538,13 +538,17 @@ with these exceptions:
         significance (MSB LSB for two-byte integers, MSB B2 B1 LSB for four-byte integers)
       </dd>
 
-      <dt id="3pq"><dfn>perceptual quantiser (PQ)</dfn>
+      <dt>perceptual quantiser (<dfn>PQ</dfn>)
       </dt>
 
       <dd>
-        <a>transfer function</a> defined in ITU-R BT.2100 Table 4. N.B. only RGB may be used in PNG, ICtCp is NOT supported. (An absolute display-referred system)
+        <a>transfer function</a> defined in ITU-R BT.2100 Table 4. (An absolute display-referred system)
       </dd>
-        
+
+      <p class="note">
+        Only RGB may be used in PNG, ICtCp is NOT supported.
+      </p>
+
       <!-- ************Page Break******************* -->
       <!-- ************Page Break******************* -->
       <!-- Maintain a fragment named "3PNGdecoder" to preserve incoming links to it -->
@@ -615,15 +619,15 @@ with these exceptions:
       <dd>
         row of <a>pixels</a> within an image or <a>interlaced PNG image</a>.
       </dd>
-        
-      <dt id="3sdr"><dfn>standard dynamic range (SDR)</dfn>
+
+      <dt>standard dynamic range (<dfn>SDR</dfn>)
       </dt>
 
       <dd>
-        an image format capable of storing images with a relatively high dynamic range similar to or in excess of the human visual system's instantaneous dynamic range (~12-14 stops). PNG allows the use of 2 HDR formats, HLG and PQ.
-      </dd>
-      
-        <dt id="3stop"><dfn>stop</dfn>
+        an image format capable of storing images with a relatively low dynamic range of 5-8 <a>stops</a>. Examples include sRGB, Display P3, ITU-R BT.709
+      <p class="note">Standard dynamic range is independent of the primaries and hence, gamut.  Wide color gamur <a>SDR</a> formats are supported by PNG.</p></dd>
+
+      <dt><dfn>stop</dfn>
       </dt>
 
       <dd>
@@ -664,14 +668,14 @@ with these exceptions:
         <p class="note">A decoder calculates the CRC for the received data and checks by comparing it to the CRC calculated by
         the encoder and appended to the data. A mismatch indicates that the data or the CRC were corrupted in transit</p>
       </dd>
-  
+
       <!-- Maintain a fragment named "3CRT" to preserve incoming links to it -->
       <dt id="3CRT">Cathode Ray Tube</dt>
       <dt><abbr title="Cathode Ray Tube">CRT</abbr></dt>
 
       <dd>vacuum tube containing one or more electron guns, which emit electron beams that are manipulated to display images on a
       phosphorescent screen</dd>
-  
+
       <!-- Maintain a fragment named "3LSB" to preserve incoming links to it -->
       <dt id="3LSB">Least Significant Byte</dt>
       <dt><abbr title="Least Significant Byte">LSB</abbr></dt>
@@ -1169,7 +1173,7 @@ with these exceptions:
           <td>Coding-independent code points</td>
           <td>
             Identifies the colour space by enumerating metadata such as the <a>transfer function</a> and colour primaries.
-            Originally for SDR and HDR video, also used for still and animated images.
+            Originally for <a>SDR</a> and <a>HDR</a> video, also used for still and animated images.
           </td>
         </tr>
 
@@ -1325,7 +1329,7 @@ with these exceptions:
       <section class="introductory">
         <h3>Introduction</h3>
 
-        <p>Animated PNG (APNG) extends the original, static-only PNG format, 
+        <p>Animated PNG (APNG) extends the original, static-only PNG format,
         adding support for <a>frame</a>-based animated images. It is intended to
         be a replacement for simple animated images that have traditionally used the GIF format [[GIF]], while adding support for
         24-bit images and 8-bit transparency, which GIF lacks.</p>
@@ -2253,7 +2257,7 @@ with these exceptions:
     <section id="6Colour-values">
       <h2>Colour types and values</h2>
 
-      <p>As explained in <a href="#4Concepts.PNGImage"></a> there are five types of PNG 
+      <p>As explained in <a href="#4Concepts.PNGImage"></a> there are five types of PNG
       <!-- Maintain "3colourType" to preserve incoming links to it -->
        image. Corresponding to each type is a <dfn id="3colourType">colour type</dfn>, which is the sum of the following values: 1
       (palette used), 2 (<a>truecolour</a> used) and 4 (alpha used). <a>greyscale</a> and <a>truecolour</a> images may have an explicit
@@ -3153,7 +3157,7 @@ with these exceptions:
           <p>For <a>colour types</a> 0 or 2, two bytes per sample are used regardless of the image bit depth (see <a href=
           "#7Integers-and-byte-order"></a>). Pixels of the specified grey sample value or RGB sample values are treated as
           transparent (equivalent to alpha value 0); all other pixels are to be treated as fully opaque (alpha value
-          2<sup>bitdepth</sup>-1). 
+          2<sup>bitdepth</sup>-1).
           If the image bit depth is less than 16, the least significant bits are used.
           Encoders should set the other bits to 0, and decoders must mask the other bits to 0 before the value is used.</p>
 
@@ -3662,11 +3666,11 @@ with these exceptions:
             images</a>. If <code>Video Full Range Flag</code> value is <code>0</code>, then the image is a <a>narrow-range
             image</a>. Narrow range images are found in video workflows where the interpretation of sample values below reference
             black (0% signal level) or above nominal peak (100% signal level). For example, [[ITU-R-BT.709]] specifies that, for
-            10-bit coding, reference black (called black level) corresponds to code value 64 and nominal peak to code value 940. 
-            In narrow range, momentary excursions defined as overshoots and undershoots exist below reference black and above nominal 
-            peak in order to preserve processing artifacts caused by filtering/compression or by uncontrolled lighting without 
-            clipping.  This can improve image quality during additional stages of processing and compression. The use of 
-            undershoot/overshoot has also been used to preserve additional color volume (both light and color) as described in 
+            10-bit coding, reference black (called black level) corresponds to code value 64 and nominal peak to code value 940.
+            In narrow range, momentary excursions defined as overshoots and undershoots exist below reference black and above nominal
+            peak in order to preserve processing artifacts caused by filtering/compression or by uncontrolled lighting without
+            clipping.  This can improve image quality during additional stages of processing and compression. The use of
+            undershoot/overshoot has also been used to preserve additional color volume (both light and color) as described in
             [[EBU-R-103]]. [[SMPTE-RP-2077]] describes full range in more detail and includes the mapping
             from <a>full-range images</a> to <a>narrow-range images</a> and describes protected code values for SDI (baseband)
             carriage.
@@ -3706,7 +3710,7 @@ with these exceptions:
 
           <aside class="example">
             <span class="chunk">cICP</span> chunk field values for a <a>full-range image</a> that uses the colour primaries and the
-            PQ <a>transfer function</a> specified at [[ITU-R-BT.2100]]:
+            <a>PQ</a> <a>transfer function</a> specified at [[ITU-R-BT.2100]]:
 
             <pre>
 9 16 0 1
@@ -3715,7 +3719,7 @@ with these exceptions:
 
           <aside class="example">
             <span class="chunk">cICP</span> chunk field values for a <a>full-range image</a> that uses the colour primaries and the
-            HLG <a>transfer function</a> specified at [[ITU-R-BT.2100]]:
+            <a>HLG</a> <a>transfer function</a> specified at [[ITU-R-BT.2100]]:
 
             <pre>
 9 18 0 1
@@ -3742,19 +3746,19 @@ with these exceptions:
           <pre>
 <!-- 109 68 67 118 -->6D 44 43 76
 </pre>
-          <p>If present, the <span class="chunk">mDCv</span> chunk characterizes 
-          the Mastering Display Color Volume (mDCv) used at the point of content creation, 
-          as specified in [[SMPTE-ST-2086]]. The mDCv provides informative static metadata to 
-          allow a destination (consumer) display to optimize it's tone and color mappings based 
-          on its inherent capabilities. The mDCv chunk should be included for PQ 
-          images. It is less common for other image formats but may be included. Color Primaries and White Point characteristics 
-          can be derived from cICP chunk formats. Specific examples of common use-cases 
+          <p>If present, the <span class="chunk">mDCv</span> chunk characterizes
+          the Mastering Display Color Volume (mDCv) used at the point of content creation,
+          as specified in [[SMPTE-ST-2086]]. The mDCv provides informative static metadata to
+          allow a destination (consumer) display to optimize it's tone and color mappings based
+          on its inherent capabilities. The mDCv chunk should be included for <a>PQ</a>
+          images. It is less common for other image formats but may be included. Color Primaries and White Point characteristics
+          can be derived from cICP chunk formats. Specific examples of common use-cases
           for ITU formats are available in [[ITU-T-Series-H-Supplement-19]].</p>
 
           <p class="note"><a href="https://github.com/w3c/PNG-spec/issues/319">Issue #319</a> discusses tone-mapping behavior when
           the <span class="chunk">mDCv</span> chunk is present.</p>
 
-          <p> If mDCv display min/max luminance are unknown, the default 
+          <p> If mDCv display min/max luminance are unknown, the default
           characteristics can be derived from the values given in the image format specification or, for ITU formats, from [[ITU-T-Series-H-Supplement-19]] Table 11 .”</p>
 
           <p>The following specifies the syntax of the <span class="chunk">mDCv</span> chunk:</p>
@@ -3809,7 +3813,7 @@ with these exceptions:
           "chunk" href="#11IDAT">IDAT</a> chunks.</p>
 
           <aside class="example">
-            Example <span class="chunk">mDCv</span> chunk mastering display colour primaries for HDR:
+            Example <span class="chunk">mDCv</span> chunk mastering display colour primaries for <a>HDR</a>:
             <table id="mDCv-chunk-hdr-primaries-example" class="numbered simple">
               <tr>
                 <th>Name</th>
@@ -3836,7 +3840,7 @@ with these exceptions:
           </aside>
 
           <aside class="example">
-            Example <span class="chunk">mDCv</span> chunk mastering display white point for HDR:
+            Example <span class="chunk">mDCv</span> chunk mastering display white point for <a>HDR</a>:
             <table id="mDCv-chunk-hdr-white-point-example" class="numbered simple">
               <tr>
                 <th>Name</th>
@@ -3853,7 +3857,7 @@ with these exceptions:
           </aside>
 
           <aside class="example">
-            Example <span class="chunk">mDCv</span> chunk mastering display maximum luminance for HDR:
+            Example <span class="chunk">mDCv</span> chunk mastering display maximum luminance for <a>HDR</a>:
             <table id="mDCv-chunk-max-luminance-example" class="numbered simple">
               <tr>
                 <th>Actual value</th>
@@ -3883,12 +3887,12 @@ with these exceptions:
           </aside>
 
 
-          <p>Below are mDCv examples for [[SMPTE-ST-2086]] with SDR content that may be native or 
-            containerized in HDR content (as described in the [[MovieLabs-Recommended-Best-Practice-for-SDR-to-HDR-Conversion]]).</p>
+          <p>Below are mDCv examples for [[SMPTE-ST-2086]] with <a>HDR</a> content that may be native or
+            containerized in <a>HDR</a> content (as described in the [[MovieLabs-Recommended-Best-Practice-for-SDR-to-HDR-Conversion]]).</p>
 
 
           <aside class="example">
-            Example <span class="chunk">mDCv</span> chunk mastering display colour primaries for SDR:
+            Example <span class="chunk">mDCv</span> chunk mastering display colour primaries for <a>SDR</a>:
             <table id="mDCv-chunk-sdr-primaries-example" class="numbered simple">
               <tr>
                 <th>Name</th>
@@ -3916,7 +3920,7 @@ with these exceptions:
           </aside>
 
           <aside class="example">
-            Example <span class="chunk">mDCv</span> chunk mastering display white point for SDR:
+            Example <span class="chunk">mDCv</span> chunk mastering display white point for <a>SDR</a>:
             <table id="mDCv-chunk-sdr-white-point-example" class="numbered simple">
               <tr>
                 <th>Name</th>
@@ -3933,8 +3937,8 @@ with these exceptions:
           </aside>
 
           <aside class="example">
-            Example <span class="chunk">mDCv</span> chunk mastering display maximum 
-            luminance using traditional live television production techniques at 100 cd/m<sup>2</sup> 
+            Example <span class="chunk">mDCv</span> chunk mastering display maximum
+            luminance using traditional live television production techniques at 100 cd/m<sup>2</sup>
             (described in [[ITU-R-BT.2035]]):
             <table id="mDCv-chunk-max-luminance-example3" class="numbered simple">
               <tr>
@@ -3950,8 +3954,8 @@ with these exceptions:
           </aside>
 
           <aside class="example">
-            Example <span class="chunk">mDCv</span> chunk mastering display maximum 
-            luminance using "single-master" live television production techniques at 203 cd/m<sup>2</sup> 
+            Example <span class="chunk">mDCv</span> chunk mastering display maximum
+            luminance using "single-master" live television production techniques at 203 cd/m<sup>2</sup>
             (described in ITU-R BT.2408 Annex Y):
             <table id="mDCv-chunk-max-luminance-example4" class="numbered simple">
               <tr>
@@ -3975,17 +3979,17 @@ with these exceptions:
           <pre>
 <!-- 99 76 76 105 -->63 4C 4C 69
 </pre>
-        
+
           <p>If present, the <span class="chunk">cLLi</span> chunk identifies two characteristics:</p>
-             
-          <p>MaxFALL (Maximum Frame Average Light Level) indicates the maximum value of the <a>frame</a> 
-             average light level (in cd/m<sup>2</sup>, also known as nits) of the entire playback sequence. MaxFALL is 
+
+          <p>MaxFALL (Maximum Frame Average Light Level) indicates the maximum value of the <a>frame</a>
+             average light level (in cd/m<sup>2</sup>, also known as nits) of the entire playback sequence. MaxFALL is
              calculated by first averaging the decoded luminance values of all the pixels in each frame,
              and then using the value for the frame with the highest value.</p>
-             
-          <p>MaxCLL (Maximum Content Light Level) indicates the maximum light level of any single 
-             pixel (in cd/m<sup>2</sup>, also known as nits) of the entire playback sequence.  There is often an algorithmic 
-             filter to eliminate false values occurring from processing or noise that could adversely 
+
+          <p>MaxCLL (Maximum Content Light Level) indicates the maximum light level of any single
+             pixel (in cd/m<sup>2</sup>, also known as nits) of the entire playback sequence.  There is often an algorithmic
+             filter to eliminate false values occurring from processing or noise that could adversely
              affect intended downstream tone mapping.</p>
 
           <p class="note"><a href="https://github.com/w3c/PNG-spec/issues/319">Issue #319</a> discusses tone-mapping behavior when
@@ -3994,7 +3998,7 @@ with these exceptions:
           <p>Each <a>frame</a> is analyzed.</p>
 
           <p>A value of zero for either MaxCLL or MaxFALL means that the value is unknown or not currently calculable.</p>
-            
+
           <p class="note">An example where this will not be calculable is when creating a live animated PNG stream, when not all frames will be available to compute the values until the stream ends.  The encoder may wish to use the value zero initially and replace this with the calculated value when the stream ends.</p>
 
            <p>The following specifies the syntax of the <span class="chunk">cLLi</span> chunk:</p>
@@ -5509,17 +5513,17 @@ output = floor((input * MAXOUTSAMPLE / MAXINSAMPLE) + 0.5)
       <p>For <a>truecolour</a> and <a>greyscale</a> images, any of the five filters may prove the most effective. If an encoder uses a
       fixed filter, the Paeth filter type is most likely to be the best.</p>
 
-      <p>For best compression of <a>truecolour</a> and <a>greyscale</a> images, 
+      <p>For best compression of <a>truecolour</a> and <a>greyscale</a> images,
       and if compression efficiency is valued over speed of compression,
       the recommended approach is adaptive filtering in which a
-      filter type is chosen for each scanline. 
-      Each unique image will have a different set of filters which perform best for it. 
-      An encoder could try every combination of filters to find what compresses best 
-      for a given image. However, when an exhaustive search is unacceptable, 
+      filter type is chosen for each scanline.
+      Each unique image will have a different set of filters which perform best for it.
+      An encoder could try every combination of filters to find what compresses best
+      for a given image. However, when an exhaustive search is unacceptable,
       here are some general heuristics which may perform well enough:
       compute the output
       scanline using all five filters, and select the filter that gives the smallest sum of absolute values of outputs. (Consider
-      the output bytes as signed differences for this test.) 
+      the output bytes as signed differences for this test.)
       This method usually outperforms any single fixed filter type choice.</p>
 
       <p>Filtering according to these recommendations is effective in conjunction with either of the two interlace methods defined
@@ -5550,13 +5554,13 @@ output = floor((input * MAXOUTSAMPLE / MAXINSAMPLE) + 0.5)
       (ISO 8859-1) character encoding, which limits the range of characters that can be used in these chunks. Encoders should
       prefer <a class="chunk" href="#11iTXt">iTXt</a> to <a class="chunk" href="#11tEXt">tEXt</a> and <a class="chunk" href=
       "#11zTXt">zTXt</a> chunks, in order to allow a wide range of characters without data loss. Encoders must convert characters
-      that use local <a>legacy character encodings</a> to the appropriate encoding when storing text. 
+      that use local <a>legacy character encodings</a> to the appropriate encoding when storing text.
       </p>
 
       <p>When creating <a href="#11iTXt" class="chunk">iTXt</a> chunks,
         encoders should follow <a href="https://encoding.spec.whatwg.org/#utf-8-encode">UTF-8 encode</a> in [[[ENCODING]]].
       </p>
-      
+
       <p>Encoders should discourage
       the creation of single lines of text longer than 79 Unicode <a>code points</a>, in order to facilitate easy reading. It is
       recommended that text items less than 1024 bytes in size should be output using uncompressed text chunks. It is recommended
@@ -5798,22 +5802,22 @@ output = floor((input * MAXOUTSAMPLE / MAXINSAMPLE) + 0.5)
     <section id="Privacy-considerations">
       <h2>Privacy considerations</h2>
 
-      <p>Some image editing tools have historically performed redaction 
-        by merely setting the alpha channel of the redacted area to zero, 
-        without also removing the actual image data. 
-        Users who rely solely on the visual appearance of such images 
-        run a privacy risk 
+      <p>Some image editing tools have historically performed redaction
+        by merely setting the alpha channel of the redacted area to zero,
+        without also removing the actual image data.
+        Users who rely solely on the visual appearance of such images
+        run a privacy risk
         because the actual image data can be easily recovered.</p>
 
-      <p>Similarly, some image editing tools have historically performed clipping 
-        by rewriting the width and height in <span class="chunk">IHDR</span> 
-        without re-encoding the image data, 
+      <p>Similarly, some image editing tools have historically performed clipping
+        by rewriting the width and height in <span class="chunk">IHDR</span>
+        without re-encoding the image data,
         which thus extends beyond the new width and height and may be recovered.</p>
 
-      <p>Images with <span class="chunk">eXIf</span> chunks 
-        may contain automatically-included data, 
-        such as photographic GPS coordinates, 
-        which could be a privacy risk if the user is unaware that the PNG image contains this data. 
+      <p>Images with <span class="chunk">eXIf</span> chunks
+        may contain automatically-included data,
+        such as photographic GPS coordinates,
+        which could be a privacy risk if the user is unaware that the PNG image contains this data.
         (Other image formats that contain EXIF, such as JPEG/JFIF, have the same privacy risk).</p>
     </section>
     <!-- Maintain a fragment named "13Chunking" to preserve incoming links to it -->
@@ -7417,7 +7421,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
     <ul>
       <!-- to 18 July 2023 -->
       <li>Explained preferable handling of trailing bytes in the final <a href="#11IDAT" class="chunk">IDAT</a> chunk for encoders and decoders.</li>
-      <li>Linked to open issue on tone-mapping HDR images in the presence of <a href="#mDCv-chunk" class="chunk">mDCv</a>.</li>
+      <li>Linked to open issue on tone-mapping <a>HDR</a> images in the presence of <a href="#mDCv-chunk" class="chunk">mDCv</a>.</li>
       <li>Follow the Encoding Standard on UTF-8 encode and decode.</li>
       <li>Added definition of a frame.</li>
       <li>Required the Matrix Coefficients in <a href="#cICP-chunk" class="chunk">cICP</a> to be zero (RGB data).</li>
@@ -7432,25 +7436,25 @@ will need to be replaced by copies of lines 17-23, but processing background ins
       <li>Improved definitions of source, reference, and PNG images.</li>
       <li>Moved concepts from the terms and definitions section to the main prose.</li>
       <!-- to 6 March 2023 -->
-      <li>Corrected error in <a href="#eXIf" class="chunk">eXIf</a> chunk, 
+      <li>Corrected error in <a href="#eXIf" class="chunk">eXIf</a> chunk,
         which conflicted with the <a href="#5ChunkOrdering">chunk ordering</a> section.</li>
       <li>Simplified <a href="#1Scope">Scope</a> section to remove redundant detail described elsewhere.</li>
       <li>Redrew chunk-ordering lattice diagrams to be clearer and more consistent.</li>
-      <li>Added a new chunk, <a href="#cLLi-chunk" class="chunk">cLLi</a>, 
+      <li>Added a new chunk, <a href="#cLLi-chunk" class="chunk">cLLi</a>,
       to describe the Maximum Single-Pixel and Frame-Average Luminance Levels
-      for both static and animated HDR PNG images.
+      for both static and animated <a>HDR</a> PNG images.
       </li>
       <li>Updated external links to latest versions, preferring https over http.</li>
       <li>Specified interoperable handling of extra sample bits, beyond the specified bit depth,
         in <a href="#11tRNS" class="chunk">tRNS</a> and <a href="#11bKGD" class="chunk">bKGD</a> chunks.
       </li>
-      <li>Added a new chunk, <a href="#mDCv-chunk" class="chunk">mDCv</a> 
-        to describe the color volume of the mastering display used to grade HDR content.</li>
+      <li>Added a new chunk, <a href="#mDCv-chunk" class="chunk">mDCv</a>
+        to describe the color volume of the mastering display used to grade <a>HDR</a> content.</li>
       <li>Used correct Unicode character names.</li>
       <li>Changed chunk type codes to use hexadecimal, rather than decimal.</li>
       <li>Described textual chunk processing more clearly.</li>
       <li>Recommended <a href="#11iTXt" class="chunk">iTXt</a> for new content.</li>
-      <li>Clarifications on the language tag field of the <a href="#11iTXt" class="chunk">iTXt</a> chunk, 
+      <li>Clarifications on the language tag field of the <a href="#11iTXt" class="chunk">iTXt</a> chunk,
         corrected examples to conform to BCP47.</li>
       <li>Updated image/apng registration appendix. APNG MIME type registered with IANA.</li>
       <li>Converted ACII-art figures to more accessible diagrams.</li>
@@ -7468,7 +7472,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
 
       <li>Added the <a class="chunk" href="#cICP-chunk">cICP</a> chunk, Coding-independent code points for video signal type
       identification, to contain image format metadata defined in [[ITU-T-H.273]] which enables PNG to contain High Dynamic Range
-      (HDR) and Wide Colour Gamut (WCG) images.
+      (<a>HDR</a>) and Wide Colour Gamut (WCG) images.
       </li>
 
       <li>The previously defined <a class="chunk" href="#eXIf">eXIf</a> chunk has been moved from the PNG-Extensions document


### PR DESCRIPTION
This is a follow up to @simontWork's PR https://github.com/w3c/PNG-spec/pull/345

Changes: 
- The SDR and HDR definitions were swapped
- Added links to HDR related terms throughout the spec
- Moved a "NB" in the transfer function definition to a Note
- Fixed all ReSpec warnings

(My editor is configured to trim trailing spaces, so there are a few lines with whitespace only changes. I hope this is OK.)
