### PR TITLE
MaxCLL and MaxFALL fixup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1173,7 +1173,7 @@ with these exceptions:
           <td>Coding-independent code points</td>
           <td>
             Identifies the colour space by enumerating metadata such as the <a>transfer function</a> and colour primaries.
-            Originally for <a>SDR</a> [[ITU-R-BT.709]] and <a>HDR</a> [[ITU-R BT.2100]] video, also used for still and animated images.
+            Originally for <a>SDR</a> (for example [[ITU-R-BT.709]]) and <a>HDR</a> [[ITU-R BT.2100]] video, also used for still and animated images.
           </td>
         </tr>
 
@@ -3751,7 +3751,7 @@ with these exceptions:
           the Mastering Display Color Volume (mDCv) used at the point of content creation, 
           as specified in [[SMPTE-ST-2086]]. The mDCv provides informative static metadata to 
           allow a destination (consumer) display to optimize it's tone and color mappings based 
-          on its inherent capabilities. The mDCv chunk should be included for both <a>PQ</a> [[ITU-R-BT.2100]] and <a>SDR</a> [[ITU-R-BT.709]]
+          on its inherent capabilities. The mDCv chunk should be included for both <a>PQ</a> [[ITU-R-BT.2100]] and <a>SDR</a> (for example [[ITU-R-BT.709]])
           images. It is less common for HLG images. Color Primaries and White Point characteristics 
           can be derived from cICP chunk formats. Specific examples of its most common use-cases 
           for images using both HDR [[ITU-R-BT.2100]] and SDR [[ITU-R-BT.709]] are available in [[ITU-T-Series-H-Supplement-19]].</p>
@@ -3759,7 +3759,7 @@ with these exceptions:
           <p class="note"><a href="https://github.com/w3c/PNG-spec/issues/319">Issue #319</a> discusses tone-mapping behavior when
           the <span class="chunk">mDCv</span> chunk is present.</p>
 
-           <p> For <a>SDR</a> [[ITU-R-BT.709]] images, if mDCv display min/max luminance are unknown, the default 
+           <p> For <a>SDR</a> (for example [[ITU-R-BT.709]]) images, if mDCv display min/max luminance are unknown, the default 
           characteristics can be derived from the values in [[ITU-T-Series-H-Supplement-19]] Table 11 .”</p>
 
 
@@ -3893,7 +3893,7 @@ with these exceptions:
           </aside>
 
 
-           <p>Below are mDCv examples for [[SMPTE-ST-2086]] with <a>SDR</a> [[ITU-R-BT.709]] content that may be native or 
+           <p>Below are mDCv examples for [[SMPTE-ST-2086]] with <a>SDR</a> (for example [[ITU-R-BT.709]]) content that may be native or 
             containerized in <a>HDR</a> [[ITU-R-BT.2100]]content (as described in the [[MovieLabs-Recommended-Best-Practice-for-SDR-to-HDR-Conversion]]).</p>
 
 
@@ -3928,7 +3928,7 @@ with these exceptions:
 
           <aside class="example">
 
-            Example <span class="chunk">mDCv</span> chunk mastering display white point for <a>SDR</a> [[ITU-R-BT.709]]:
+            Example <span class="chunk">mDCv</span> chunk mastering display white point for <a>SDR</a> (for example [[ITU-R-BT.709]]):
 
             <table id="mDCv-chunk-sdr-white-point-example" class="numbered simple">
               <tr>
@@ -3947,7 +3947,7 @@ with these exceptions:
 
           <aside class="example">
             Example <span class="chunk">mDCv</span> chunk mastering display maximum 
-          luminance using traditional <a>SDR</a> [[ITU-R-BT.709]]shading techniques at 100 cd/m<sup>2</sup> 
+          luminance using traditional <a>SDR</a> (for example [[ITU-R-BT.709]])shading techniques at 100 cd/m<sup>2</sup> 
 
             (described in [[ITU-R-BT.2035]]):
             <table id="mDCv-chunk-max-luminance-example3" class="numbered simple">
@@ -3966,7 +3966,7 @@ with these exceptions:
           <aside class="example">
 
             Example <span class="chunk">mDCv</span> chunk mastering display maximum 
-          luminance using "single-master" <a>SDR</a> [[ITU-R-BT.709]]shading techniques at 203 cd/m<sup>2</sup> 
+          luminance using "single-master" <a>SDR</a> (for example [[ITU-R-BT.709]])shading techniques at 203 cd/m<sup>2</sup> 
             (described in ITU-R BT.2408 Annex Y):
             <table id="mDCv-chunk-max-luminance-example4" class="numbered simple">
               <tr>
@@ -4010,7 +4010,7 @@ with these exceptions:
             that could adversely affect intended downstream tone mapping.</p>
 
           <p class="note"><a href="https://shop.cta.tech/products/hdr-static-metadata-extensions">CTA 861.G</a> is available 
-            as a free download. It describes the method of calculation for generating the cLLi values</p>
+            as a free download. It describes the method of calculation for generating the cLLi values.</p>
 
           <p class="note"><a href="https://github.com/SMPTE/st2067-21">SMPTE ST 2086-21</a> Section 7.5 adds additional
             information in Section 7.5 in the case where the cLLi values are unknown and have not been calculated.</p> 

--- a/index.html
+++ b/index.html
@@ -92,6 +92,12 @@
           href: "https://poynton.ca/ColorFAQ.html",
           date: "2009-10-19"
         },
+        "CTA-861.3-A": {
+          title: "HDR Static Metadata Extensions (CTA-861.3-A)",
+          publisher: "Consumer Technology Association",
+          date: "2015-01",
+          href: "https://shop.cta.tech/products/hdr-static-metadata-extensions"
+        },
         "ICC-2": {
           title: "Specification ICC.2:2019 (Profile version 5.0.0 - iccMAX)",
           date: "2019",
@@ -4015,8 +4021,7 @@ with these exceptions:
             There is often an algorithmic filter to eliminate false values occurring from processing or noise 
             that could adversely affect intended downstream tone mapping.</p>
 
-          <p class="note"><a href="https://shop.cta.tech/products/hdr-static-metadata-extensions">CTA 861.G</a> is available 
-            as a free download. It describes the method of calculation for generating the cLLi values.</p>
+          <p class="note">[[CTA-861.3-A]] describes the method of calculation for generating the cLLi values.</p>
 
           <p class="note">[[SMPTE-ST-2067-21]] Section 7.5 adds additional
             information in Section 7.5 in the case where the cLLi values are unknown and have not been calculated.</p> 

--- a/index.html
+++ b/index.html
@@ -110,6 +110,13 @@
           href: "https://poynton.ca/GammaFAQ.html",
           date: "1998-08-04"
         },
+        "HDR-Static-Meta": {
+          title: "On the Calculation and Usage of HDR Static Content Metadata",
+          authors: ["Smith, Michael D.", "Zink, Michael"],
+          publisher: "Society of Motion Picture and Television Engineers",
+          date: "2021-08-05",
+          href: "https://doi.org/10.5594/JMI.2021.3090176"
+        },
         "Hill": {
           title: "Comparative analysis of the quantization of color spaces on the basis of the CIELAB color-difference formula",
           authors: ["Hill, B.", "Roger, Th.", "Vorhagen, F.W."],
@@ -4021,7 +4028,12 @@ with these exceptions:
             There is often an algorithmic filter to eliminate false values occurring from processing or noise 
             that could adversely affect intended downstream tone mapping.</p>
 
-          <p class="note">[[CTA-861.3-A]] describes the method of calculation for generating the cLLi values.</p>
+          <p class="note">[[CTA-861.3-A]] describes the method of calculation for generating the cLLi values,
+            but does not specify any filtering.
+            [[HDR-Static-Meta]] describes an improved method which rejects extreme values from 
+            statistical outliers, noise or ringing from resampling filters, 
+            and is recommended for practical implementations.
+          </p>
 
           <p class="note">[[SMPTE-ST-2067-21]] Section 7.5 adds additional
             information in Section 7.5 in the case where the cLLi values are unknown and have not been calculated.</p> 

--- a/index.html
+++ b/index.html
@@ -4028,7 +4028,8 @@ with these exceptions:
             There is often an algorithmic filter to eliminate false values occurring from processing or noise 
             that could adversely affect intended downstream tone mapping.</p>
 
-          <p class="note">[[CTA-861.3-A]] describes the method of calculation for generating the cLLi values,
+          <p class="note">[[CTA-861.3-A]] describes the method of calculation for generating the
+            <span class="chunk">cLLi</span> values,
             but does not specify any filtering.
             [[HDR-Static-Meta]] describes an improved method which rejects extreme values from 
             statistical outliers, noise or ringing from resampling filters, 
@@ -4036,7 +4037,7 @@ with these exceptions:
           </p>
 
           <p class="note">[[SMPTE-ST-2067-21]] Section 7.5 adds additional
-            information in Section 7.5 in the case where the cLLi values are unknown and have not been calculated.</p> 
+            information in Section 7.5 in the case where the <span class="chunk">cLLi</span> values are unknown and have not been calculated.</p> 
 
           <p class="note"><a href="https://github.com/w3c/PNG-spec/issues/319">Issue #319</a> discusses tone-mapping behavior when
           the <span class="chunk">cLLi</span> chunk is present.</p>

--- a/index.html
+++ b/index.html
@@ -222,6 +222,12 @@
           date: "1 November 1993",
           href: "https://standards.globalspec.com/std/1284890/smpte-rp-177"
         },
+        "SMPTE-ST-2067-21": {
+          title: "Interoperable Master Format — Application #2E",
+          publisher: "Society of Motion Picture and Television Engineers",
+          date: "2023-02-20",
+          href: "https://doi.org/10.5594/SMPTE.ST2067-21.2023"
+        },
         "SMPTE-RP-2077": {
           title: "Full-Range Image Mapping",
           publisher: "Society of Motion Picture and Television Engineers",
@@ -4012,9 +4018,8 @@ with these exceptions:
           <p class="note"><a href="https://shop.cta.tech/products/hdr-static-metadata-extensions">CTA 861.G</a> is available 
             as a free download. It describes the method of calculation for generating the cLLi values.</p>
 
-          <p class="note"><a href="https://github.com/SMPTE/st2067-21">SMPTE ST 2086-21</a> Section 7.5 adds additional
+          <p class="note">[[SMPTE-ST-2067-21]] Section 7.5 adds additional
             information in Section 7.5 in the case where the cLLi values are unknown and have not been calculated.</p> 
-
 
           <p class="note"><a href="https://github.com/w3c/PNG-spec/issues/319">Issue #319</a> discusses tone-mapping behavior when
           the <span class="chunk">cLLi</span> chunk is present.</p>

--- a/index.html
+++ b/index.html
@@ -1179,7 +1179,7 @@ with these exceptions:
           <td>Coding-independent code points</td>
           <td>
             Identifies the colour space by enumerating metadata such as the <a>transfer function</a> and colour primaries.
-            Originally for <a>SDR</a> (for example [[ITU-R-BT.709]]) and <a>HDR</a> [[ITU-R BT.2100]] video, also used for still and animated images.
+            Originally for <a>SDR</a> (for example [[ITU-R-BT.709]]) and <a>HDR</a> [[ITU-R-BT.2100]] video, also used for still and animated images.
           </td>
         </tr>
 

--- a/index.html
+++ b/index.html
@@ -4010,7 +4010,7 @@ with these exceptions:
 <!-- 99 76 76 105 -->63 4C 4C 69
 </pre>
 
-          <p>If present, the <span class="chunk">cLLi</span> chunk identifies two characteristics:</p>
+          <p>If present, the <span class="chunk">cLLi</span> chunk identifies two characteristics of <a>HDR</a> content:</p>
 
           <p>The <span class="chunk">cLLi</span> chunk adds static metadata which provides an opportunity
           to optimize tone mapping of the associated content to a specific target display. This is 


### PR DESCRIPTION
As [discussed on the issue](https://github.com/w3c/PNG-spec/issues/337#issuecomment-1654365393) and also [on the earlier PR](https://github.com/w3c/PNG-spec/pull/339/files#r1289679856) this follow-on PR fixes up some [minor issues](https://github.com/w3c/PNG-spec/pull/339#issuecomment-1691984267) and adds a reference to "On the Calculation and Usage of HDR Static Content Metadata".

Previous inline references have been updated to Informative References.

A couple of minor markup issues corrected and a broken reference to BT.2100 fixed