### PR TITLE
Added changes since WD of 20 July 2023

### DIFF
--- a/index.html
+++ b/index.html
@@ -7439,6 +7439,21 @@ will need to be replaced by copies of lines 17-23, but processing background ins
   <section id="F-ChangeList" class="appendix informative">
     <h2 class="Annex">Changes</h2>
 
+    <h3 id="changes-20230720">Changes since the <a href="https://www.w3.org/TR/2023/WD-png-3-20230720/">
+      Working Draft of 20 July 2023 (Third Edition)</a></h3>
+
+    <ul>
+      <!-- to 26 Aug 2023 -->
+      <li>Added guidance on calculating MaxCLL and MaxFALL values</li>
+      <li>Added example (live streaming) where <a href="#cLLi-chunk" class="chunk">cLLi</a> could not be pre-calculated</li>
+      <li>Added definitions for stop, SDR, HDR, HLG and PQ</li>
+      <li>Clarified definition of narrow-range</li>
+      <li>Updated ITU-T H Suppl. 19 reference to latest version</li>
+      <li>Added Simon Thompson as an author</li>
+      <li>Mandated current browser handling of out-of-range palette indices</li>
+      <li>Updated "Additional Information" table to add <a href="#mDCv-chunk" class="chunk">mDCv</a> and <a href="#cLLi-chunk" class="chunk">cLLi</a>.</li>
+    </ul>
+
     <h3 id="changes-20221025">Changes since the <a href="https://www.w3.org/TR/2022/WD-png-3-20221025/">
       First Public Working Draft of 25 October 2022 (Third Edition)</a></h3>
 


### PR DESCRIPTION
We were missing changes since the [20 July 2023 WD](https://www.w3.org/TR/2023/WD-png-3-20230720/), and the CR transition needs a link to the latest changes