### PR TITLE
mDCV chunk spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,18 +285,6 @@
           publisher: "ITU",
           date: "2021-04",
           href: "https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=14652"
-        },
-        "MovieLabs-Recommended-Best-Practice-for-SDR-to-HDR-Conversion": {
-            title: "MovieLabs Best Practices for Mapping BT.709 Content to HDR10 for Consumer Distribution",
-            publisher: "Motion Picture Laboratories(MovieLabs)",
-            date: "2018",
-            href: "https://www.movielabs.com/ngvideo/MovieLabs_Mapping_BT.709_to_HDR10_v1.0.pdf"
-        },
-        "ITU-R-BT.2035": {
-            title: "A reference viewing environment for evaluation of HDTV program material or completed programmes",
-            publisher: "ITU",
-            date: "2013-07",
-            href: "https://www.itu.int/rec/R-REC-BT.2035-0-201307-I"
         }
       }
     }
@@ -3778,29 +3766,25 @@ with these exceptions:
 <!-- 109 68 67 118 -->6D 44 43 76
 </pre>
 
-          <p>If present, the <span class="chunk">mDCv</span> chunk characterizes 
-          the Mastering Display Color Volume (mDCv) used at the point of content creation, 
-          as specified in [[SMPTE-ST-2086]]. The mDCv chunk provides informative static metadata which 
-          allows a target (consumer) display to potentially optimize it's tone mapping decisions 
-          on a comparison of its inherent capabilities versus the original mastering displays capabilites.</p>
-          
-          <p>mDCv is typically used with the <a>PQ</a>[[ITU-R-BT.2100] transfer function
-          and is commonly then called HDR10 (PQ with ST 2086). The mDCv chunk may be 
-          included with <a>PQ</a> [[ITU-R-BT.2100]], <a>SDR</a> (for example [[ITU-R-BT.709]]) and <a>HLG</a> [[ITU-R-BT.2100]] 
-          and other image formats (even though mDCv use in some of them may be less common). 
-          
-          Color Primaries and White Point characteristics can be derived from cICP chunk formats. 
-          Specific examples of its most common use-cases for images using both HDR [[ITU-R-BT.2100]] 
-          and SDR [[ITU-R-BT.709]] are available in [[ITU-T-Series-H-Supplement-19]].</p>
+          <p>If present, the <span class="chunk">mDCv</span> chunk characterizes
+          the Mastering Display Color Volume (mDCv) used at the point of content creation,
+          as specified in [[SMPTE-ST-2086]]. The mDCv chunk provides informative static metadata which
+          allows a target (consumer) display to potentially optimize its tone mapping decisions
+          on a comparison of its inherent capabilities versus the original mastering display's capabilites.</p>
+
+          <p>mDCv is typically used with the <a>PQ</a> [[ITU-R-BT.2100]] transfer function
+          and is commonly then called HDR10 (PQ with [[SMPTE-ST-2086]]), and may may be
+          included with other image formats.
+          Color primaries and white point characteristics can be derived from cICP chunk formats.
+          Specific examples of its most common use cases for images using both <a>HDR</a>
+          and [[ITU-R-BT.709]] SDR are available in [[ITU-T-Series-H-Supplement-19]].</p>
 
 
           <p class="note"><a href="https://github.com/w3c/PNG-spec/issues/319">Issue #319</a> discusses tone-mapping behavior when
           the <span class="chunk">mDCv</span> chunk is present.</p>
 
-
-           <p> For <a>SDR</a> (for example [[ITU-R-BT.709]]) images, if mDCv display min/max luminance are unknown, the default 
-          characteristics can be derived from the values in [[ITU-T-Series-H-Supplement-19]] Table 11 .”</p>
-
+          <p>For <a>SDR</a> images, if mDCv display min/max luminance are unknown, the default
+          characteristics can be derived from the values in [[ITU-T-Series-H-Supplement-19]] Table 11 or from the relevant <a>SDR</a> specification.</p>
 
           <p>The following specifies the syntax of the <span class="chunk">mDCv</span> chunk:</p>
 
@@ -3853,8 +3837,9 @@ with these exceptions:
           <p>The <span class="chunk">mDCv</span> chunk MUST come before the <a class="chunk" href="#11PLTE">PLTE</a> and <a class=
           "chunk" href="#11IDAT">IDAT</a> chunks.</p>
 
-          <aside class="example">
+          <p>Below are mDCv examples for [[ITU-R-BT.2100]] <a>HDR</a>.</p>
 
+          <aside class="example">
             Example <span class="chunk">mDCv</span> chunk mastering display colour primaries for <a>HDR</a> [[ITU-R-BT.2100]]:
             <table id="mDCv-chunk-hdr-primaries-example" class="numbered simple">
               <tr>
@@ -3903,7 +3888,7 @@ with these exceptions:
 
             Example <span class="chunk">mDCv</span> chunk mastering display maximum luminance for <a>HDR</a> [[ITU-R-BT.2100]]:
 
-            <table id="mDCv-chunk-max-luminance-example" class="numbered simple">
+            <table id="mDCv-chunk-hdr-max-luminance-example" class="numbered simple">
               <tr>
                 <th>Actual value</th>
                 <th>Stored value</th>
@@ -3918,7 +3903,7 @@ with these exceptions:
 
           <aside class="example">
             Example <span class="chunk">mDCv</span> chunk mastering display minimum luminance:
-            <table id="mDCv-chunk-min-luminance-example2" class="numbered simple">
+            <table id="mDCv-chunk-hdr-min-luminance-example" class="numbered simple">
               <tr>
                 <th>Actual value</th>
                 <th>Stored value</th>
@@ -3931,14 +3916,10 @@ with these exceptions:
             </table>
           </aside>
 
-
-
-           <p>Below are mDCv examples for [[SMPTE-ST-2086]] with <a>SDR</a> (for example [[ITU-R-BT.709]])  content that may be native or 
-            containerized in <a>HDR</a> [[ITU-R-BT.2100]]content (as described in the [[MovieLabs-Recommended-Best-Practice-for-SDR-to-HDR-Conversion]]).</p>
-
+          <p>Below are mDCv examples for [[SRGB]] <a>SDR</a>.</p>
 
           <aside class="example">
-            Example <span class="chunk">mDCv</span> chunk mastering display colour primaries for SDR [[ITU-R-BT.709]]:
+            Example <span class="chunk">mDCv</span> chunk mastering display colour primaries for [[SRGB]]:
 
             <table id="mDCv-chunk-sdr-primaries-example" class="numbered simple">
               <tr>
@@ -3948,7 +3929,7 @@ with these exceptions:
               </tr>
 
               <tr>
-                <td rowspan="3">Colour primaries specified in [[ITU-R-BT.709]]</td>
+                <td rowspan="3">Colour primaries specified in [[SRGB]]</td>
                 <td>(0.640, 0.330)</td>
                 <td>{ 32000, 16500 }</td>
               </tr>
@@ -3967,8 +3948,7 @@ with these exceptions:
           </aside>
 
           <aside class="example">
-
-            Example <span class="chunk">mDCv</span> chunk mastering display white point for <a>SDR</a> (for example [[ITU-R-BT.709]]) 
+            Example <span class="chunk">mDCv</span> chunk mastering display white point for [[SRGB]]:
 
             <table id="mDCv-chunk-sdr-white-point-example" class="numbered simple">
               <tr>
@@ -3986,42 +3966,35 @@ with these exceptions:
           </aside>
 
           <aside class="example">
-            Example <span class="chunk">mDCv</span> chunk mastering display maximum 
-          luminance using traditional <a>SDR</a> (for example [[ITU-R-BT.709]]) shading techniques at 100 cd/m<sup>2</sup> 
-
-            (described in [[ITU-R-BT.2035]]):
-            <table id="mDCv-chunk-max-luminance-example3" class="numbered simple">
+            Example <span class="chunk">mDCv</span> chunk mastering display maximum
+          luminance for [[SRGB]] <a>SDR</a>:
+            <table id="mDCv-chunk-sdr-max-luminance-example" class="numbered simple">
               <tr>
                 <th>Actual value</th>
                 <th>Stored value</th>
               </tr>
 
               <tr>
-                <td>100 cd/m<sup>2</sup></td>
-                <td>1000000</td>
+                <td>80 cd/m<sup>2</sup></td>
+                <td>800000</td>
               </tr>
             </table>
           </aside>
 
           <aside class="example">
-
-            Example <span class="chunk">mDCv</span> chunk mastering display maximum 
-          luminance using "single-master" <a>SDR</a> (for example [[ITU-R-BT.709]]) shading techniques at 203 cd/m<sup>2</sup> 
-
-            (described in ITU-R BT.2408 Annex Y):
-            <table id="mDCv-chunk-max-luminance-example4" class="numbered simple">
+            Example mDCv chunk mastering display minimum luminance for [[SRGB]] <a>SDR</a>:
+            <table id="mDCv-chunk-sdr-min-luminance-example" class="numbered simple">
               <tr>
                 <th>Actual value</th>
                 <th>Stored value</th>
               </tr>
 
               <tr>
-                <td>203 cd/m<sup>2</sup></td>
-                <td>2030000</td>
+                <td>0.05 cd/m<sup>2</sup></td>
+                <td>500</td>
               </tr>
             </table>
           </aside>
-
         </section>
 
         <section id="cLLi-chunk">

--- a/index.html
+++ b/index.html
@@ -3774,8 +3774,7 @@ with these exceptions:
           on a comparison of its inherent capabilities versus the original mastering display's capabilites.</p>
 
           <p>mDCv is typically used with the <a>PQ</a> [[ITU-R-BT.2100]] transfer function
-          and is commonly then called HDR10 (PQ with [[SMPTE-ST-2086]]), and may may be
-          included with other image formats.
+          and is commonly then called HDR10 (PQ with [[SMPTE-ST-2086]]), and may be included with other image formats.
           Color primaries and white point characteristics can be derived from cICP chunk formats.
           Specific examples of its most common use cases for images using both <a>HDR</a>
           and [[ITU-R-BT.709]] SDR are available in [[ITU-T-Series-H-Supplement-19]].</p>

--- a/index.html
+++ b/index.html
@@ -100,6 +100,13 @@
           date: "2015-01",
           href: "https://shop.cta.tech/products/hdr-static-metadata-extensions"
         },
+        "Display-P3": {
+          title: "Display P3",
+          authors: ["Apple, Inc"],
+          date: "2022-02",
+          publisher: "ICC",
+          href: "https://www.color.org/chardata/rgb/DisplayP3.xalter"
+        },
         "ICC-2": {
           title: "Specification ICC.2:2019 (Profile version 5.0.0 - iccMAX)",
           date: "2019",
@@ -487,7 +494,7 @@ with these exceptions:
       </dt>
 
       <dd>
-        an image format capable of storing images with a relatively high dynamic range similar to or in excess of the human visual system's instantaneous dynamic range (~12-14 <a>stops</a>). PNG allows the use of two <a>HDR</a> formats, <a>HLG</a> and <a>PQ</a>.
+        an image format capable of storing images with a relatively high dynamic range similar to or in excess of the human visual system's instantaneous dynamic range (~12-14 <a>stops</a>). PNG allows the use of two <a>HDR</a> formats, <a>HLG</a> and <a>PQ</a> [[ITU-R-BT.2100]].
       </dd>
 
       <dt>hybrid log-gamma (<dfn>HLG</dfn>)
@@ -563,7 +570,7 @@ with these exceptions:
       </dt>
 
       <dd>
-        <a>transfer function</a> defined in ITU-R BT.2100 Table 4. (An absolute display-referred system.)
+        <a>transfer function</a> defined in [[ITU-R-BT.2100]] Table 4. (An absolute display-referred system.)
       </dd>
 
       <p class="note">
@@ -645,7 +652,7 @@ with these exceptions:
       </dt>
 
       <dd>
-        an image format capable of storing images with a relatively low dynamic range of 5-8 <a>stops</a>. Examples include sRGB, Display P3, ITU-R BT.709
+        an image format capable of storing images with a relatively low dynamic range of 5-8 <a>stops</a>. Examples include [[SRGB]], [[Display-P3]], [[ITU-R-BT.709]].
       <p class="note">Standard dynamic range is independent of the primaries and hence, gamut. Wide color gamut <a>SDR</a> formats are supported by PNG.</p></dd>
 
       <dt><dfn>stop</dfn>
@@ -1195,8 +1202,7 @@ with these exceptions:
           <td>
             Identifies the colour space by enumerating metadata such as the <a>transfer function</a> and colour primaries.
 
-            Originally for <a>SDR</a> (for example [[ITU-R-BT.709]]) and <a>HDR</a> [[ITU-R-BT.2100]] video, also used for still and animated images.
-
+            Originally for <a>SDR</a> and <a>HDR</a> video, also used for still and animated images.
           </td>
         </tr>
 

--- a/index.html
+++ b/index.html
@@ -390,14 +390,14 @@ with these exceptions:
       <dt>octet</dt>
 
       <dd>8-bit binary integer in the range [0, 255] where the most significant bit is bit 7 and the least significant
-      bit is bit 0</dd>
+      bit is bit 0.</dd>
       <!-- Maintain a fragment named "3byteOrder" to preserve incoming links to it -->
 
       <dt id="3byteOrder"><dfn>byte order</dfn>
       </dt>
 
       <dd>
-        ordering of <a>bytes</a> for multi-byte data values
+        ordering of <a>bytes</a> for multi-byte data values.
       </dd>
 
       <!-- Maintain a fragment named "3chromaticity" to preserve incoming links to it -->
@@ -405,7 +405,7 @@ with these exceptions:
       <dt id="3chromaticity"><dfn>chromaticity</dfn>
       </dt>
 
-      <dd>pair of <i>x</i> and <i>y</i> values in the <i>xyY</i> space specified at [[COLORIMETRY]]
+      <dd>pair of <i>x</i> and <i>y</i> values in the <i>xyY</i> space specified at [[COLORIMETRY]].
 
       <p class="note">Chromaticity is a measure of the quality of a color regardless of its luminance.</p></dd>
 
@@ -415,7 +415,7 @@ with these exceptions:
       </dt>
 
       <dd>form an image by merging a foreground image and a background image, using transparency information to determine
-      where and to what extent the background should be visible
+      where and to what extent the background should be visible.
       <p class="note">The foreground image is said to be <a>composited</a> against the background.</p>
       </dd>
 
@@ -425,7 +425,7 @@ with these exceptions:
       </dt>
 
       <dd>
-        sequence of <a>bytes</a>
+        sequence of <a>bytes</a>.
       </dd>
       <!-- Maintain a fragment named "3deflate" to preserve incoming links to it -->
 
@@ -433,7 +433,7 @@ with these exceptions:
       </dt>
 
       <dd>
-        member of the <a>LZ77</a> family of compression methods
+        member of the <a>LZ77</a> family of compression methods.
 
         <p>SOURCE: [[RFC1951]]</p>
       </dd>
@@ -458,7 +458,7 @@ with these exceptions:
       </dt>
 
       <dd>
-        the final digital storage area for the image shown by most types of computer display
+        the final digital storage area for the image shown by most types of computer display.
 
         <p class="note">Software causes an image to appear on screen by loading the image into the <a>frame buffer</a>.</p>
       </dd>
@@ -466,13 +466,13 @@ with these exceptions:
       <dt><dfn>fully transparent black</dfn>
       </dt>
 
-      <dd>pixel where the red, green, blue and alpha components are all equal to zero</dd>
+      <dd>pixel where the red, green, blue and alpha components are all equal to zero.</dd>
 
       <dt><dfn>gamma value</dfn>
       </dt>
 
       <dd>
-        value of the exponent of a <a>gamma</a> <a>transfer function</a>
+        value of the exponent of a <a>gamma</a> <a>transfer function</a>.
       </dd>
       <!-- Maintain a fragment named "3gamma" to preserve incoming links to it -->
 
@@ -480,7 +480,7 @@ with these exceptions:
       </dt>
 
       <dd>
-        power-law <a>transfer function</a>
+        power-law <a>transfer function</a>.
       </dd>
 
       <dt>high dynamic range (<dfn>HDR</dfn>)
@@ -494,14 +494,14 @@ with these exceptions:
       </dt>
 
       <dd>
-        <a>transfer function</a> defined in [[ITU-R-BT.2100]] Table 5. (A relative scene-referred system)
+        <a>transfer function</a> defined in [[ITU-R-BT.2100]] Table 5. (A relative scene-referred system.)
       </dd>
 
       <dt><dfn>full-range image</dfn>
       </dt>
 
       <dd>image where reference black and white correspond, respectively, to sample values <code>0</code> and <code>2<sup>bit depth</sup> -
-      1</code></dd>
+      1</code>.</dd>
 
       <!-- Maintain a fragment named "3imageData" to preserve incoming links to it -->
 
@@ -509,7 +509,7 @@ with these exceptions:
       </dt>
 
       <dd>
-        1-dimensional array of <a>scanlines</a> within an image
+        1-dimensional array of <a>scanlines</a> within an image.
       </dd>
 
       <!-- Maintain a fragment named "3interlacedPNGimage" to preserve incoming links to it -->
@@ -518,21 +518,21 @@ with these exceptions:
       </dt>
 
       <dd>
-        sequence of <a>reduced images</a> generated from the <a>PNG image</a> by <a>pass extraction</a>
+        sequence of <a>reduced images</a> generated from the <a>PNG image</a> by <a>pass extraction</a>.
       </dd>
       <!-- Maintain a fragment named "3losslessCompression" to preserve incoming links to it -->
 
       <dt id="3losslessCompression"><dfn>lossless</dfn>
       </dt>
 
-      <dd>method of data compression that permits reconstruction of the original data exactly, bit-for-bit</dd>
+      <dd>method of data compression that permits reconstruction of the original data exactly, bit-for-bit.</dd>
       <!-- Maintain a fragment named "3luminance" to preserve incoming links to it -->
 
       <dt id="3luminance"><dfn>luminance</dfn>
       </dt>
 
       <dd>
-        perceived brightness of a colour
+        perceived brightness of a colour.
 
         <p class="note">Luminance and <a>chromaticity</a> together fully define a perceived colour. A formal definition of
         luminance is found at [[COLORIMETRY]].</p>
@@ -548,7 +548,7 @@ with these exceptions:
       </dt>
 
       <dd>Image where reference black and white do not correspond, respectively, to sample values <code>0</code> and
-      <code>2<sup>bit depth</sup> - 1</code></dd>
+      <code>2<sup>bit depth</sup> - 1</code>.</dd>
       <!-- Maintain a fragment named "3networkByteOrder" to preserve incoming links to it -->
 
       <dt id="3networkByteOrder"><dfn>network byte order</dfn>
@@ -556,14 +556,14 @@ with these exceptions:
 
       <dd>
         <a>byte order</a> in which the most significant byte comes first, then the less significant bytes in descending order of
-        significance (MSB LSB for two-byte integers, MSB B2 B1 LSB for four-byte integers)
+        significance (MSB LSB for two-byte integers, MSB B2 B1 LSB for four-byte integers).
       </dd>
 
       <dt>perceptual quantiser (<dfn>PQ</dfn>)
       </dt>
 
       <dd>
-        <a>transfer function</a> defined in ITU-R BT.2100 Table 4. (An absolute display-referred system)
+        <a>transfer function</a> defined in ITU-R BT.2100 Table 4. (An absolute display-referred system.)
       </dd>
 
       <p class="note">
@@ -578,7 +578,7 @@ with these exceptions:
 
       <dd>
         process or device that reconstructs the <a>reference image</a> from a <a>PNG datastream</a> and generates a
-        corresponding <a>delivered image</a>
+        corresponding <a>delivered image</a>.
       </dd>
       <!-- Maintain a fragment named "3PNGeditor" to preserve incoming links to it -->
 
@@ -587,7 +587,7 @@ with these exceptions:
 
       <dd>
         process or device that creates a modification of an existing <a>PNG datastream</a>, preserving unmodified ancillary
-        information wherever possible, and obeying the <a>chunk</a> ordering rules, even for unknown chunk types
+        information wherever possible, and obeying the <a>chunk</a> ordering rules, even for unknown chunk types.
       </dd>
       <!-- Maintain a fragment named "3PNGencoder" to preserve incoming links to it -->
 
@@ -596,7 +596,7 @@ with these exceptions:
 
       <dd>
         process or device which constructs a <a>reference image</a> from a <a>source image</a>, and generates a <a>PNG
-        datastream</a> representing the reference image
+        datastream</a> representing the reference image.
       </dd>
       <!-- Maintain a fragment named "3PNGfile" to preserve incoming links to it -->
 
@@ -604,7 +604,7 @@ with these exceptions:
       </dt>
 
       <dd>
-        <a>PNG datastream</a> stored as a file
+        <a>PNG datastream</a> stored as a file.
       </dd>
       <!-- Maintain a fragment named "3PNGfourByteUnSignedInteger" to preserve incoming links to it -->
 
@@ -623,14 +623,14 @@ with these exceptions:
       </dt>
 
       <dd>
-        intersection of a <a>channel</a> and a <a>pixel</a> in an image
+        intersection of a <a>channel</a> and a <a>pixel</a> in an image.
       </dd>
       <!-- Maintain a fragment named "3sampleDepth" to preserve incoming links to it -->
 
       <dt id="3sampleDepth">sample depth</dt>
 
       <dd>
-        number of bits used to represent a <a>sample</a> value
+        number of bits used to represent a <a>sample</a> value.
       </dd>
       <!-- Maintain a fragment named "3scanline" to preserve incoming links to it -->
 
@@ -658,7 +658,7 @@ with these exceptions:
       <dt><dfn>transfer function</dfn>
       </dt>
 
-      <dd>function relating image luminance with image samples</dd>
+      <dd>function relating image luminance with image samples.</dd>
       <!-- Maintain a fragment named "3whitePoint" to preserve incoming links to it -->
 
       <dt id="3whitePoint"><dfn>white point</dfn>
@@ -677,7 +677,7 @@ with these exceptions:
 
         <p>SOURCE: [[rfc1950]]</p>
 
-        <p class="note">Also refers to the name of a library containing a sample implementation of this method</p>
+        <p class="note">Also refers to the name of a library containing a sample implementation of this method.</p>
       </dd>
 
       <!-- Maintain a fragment named "3CRC" to preserve incoming links to it -->
@@ -687,7 +687,7 @@ with these exceptions:
         <p>type of check value designed to detect most transmission errors.</p>
 
         <p class="note">A decoder calculates the CRC for the received data and checks by comparing it to the CRC calculated by
-        the encoder and appended to the data. A mismatch indicates that the data or the CRC were corrupted in transit</p>
+        the encoder and appended to the data. A mismatch indicates that the data or the CRC were corrupted in transit.</p>
       </dd>
 
       <!-- Maintain a fragment named "3CRT" to preserve incoming links to it -->
@@ -695,20 +695,20 @@ with these exceptions:
       <dt><abbr title="Cathode Ray Tube">CRT</abbr></dt>
 
       <dd>vacuum tube containing one or more electron guns, which emit electron beams that are manipulated to display images on a
-      phosphorescent screen</dd>
+      phosphorescent screen.</dd>
 
       <!-- Maintain a fragment named "3LSB" to preserve incoming links to it -->
       <dt id="3LSB">Least Significant Byte</dt>
       <dt><abbr title="Least Significant Byte">LSB</abbr></dt>
       <dd>
-        Least significant byte of a multi-<a>byte</a> value
+        Least significant byte of a multi-<a>byte</a> value.
       </dd>
       <!-- Maintain a fragment named "3MSB" to preserve incoming links to it -->
       <dt id="3MSB">Most Significant Byte</dt>
       <dt><abbr title="Most Significant Byte">MSB</abbr></dt>
 
       <dd>
-        Most significant byte of a multi-<a>byte</a> value
+        Most significant byte of a multi-<a>byte</a> value.
       </dd>
     </dl>
   </section>
@@ -1680,7 +1680,7 @@ with these exceptions:
 
         <tr>
           <td>Chunk Data</td>
-          <td>The data bytes appropriate to the chunk type, if any. 
+          <td>The data bytes appropriate to the chunk type, if any.
             <span id="zero-length-data">This field can be of zero length.</span></td>
         </tr>
 

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
         { name: "Chris Lilley", url: "https://svgees.us", company: "W3C", companyURL: "https://www.w3.org" },
         { name: "Dave Martindale" },
         { name: "Owen Mortensen" },
+        { name: "Chris Needham", url: "https://chrisneedham.com/about" },
         { name: "Stuart Parmenter"},
         { name: "Keith S. Pickens" },
         { name: "Robert P. Poole" },

--- a/index.html
+++ b/index.html
@@ -3916,7 +3916,7 @@ with these exceptions:
             </table>
           </aside>
 
-          <p>Below are mDCv examples for [[SRGB]] <a>SDR</a>.</p>
+          <p>Below are mDCv examples for [[Display-P3]] <a>SDR</a>.</p>
 
           <aside class="example">
             Example <span class="chunk">mDCv</span> chunk mastering display colour primaries for [[SRGB]]:
@@ -3929,26 +3929,25 @@ with these exceptions:
               </tr>
 
               <tr>
-                <td rowspan="3">Colour primaries specified in [[SRGB]]</td>
-                <td>(0.640, 0.330)</td>
-                <td>{ 32000, 16500 }</td>
+                <td rowspan="3">Colour primaries specified in [[Display-P3]]</td>
+                <td>(0.68, 0.32)</td>
+                <td>{ 34000, 16000 }</td>
               </tr>
 
               <tr>
-                <td>(0.300, 0.600)</td>
-                <td>{ 15000, 30000 }</td>
+                <td>(0.265, 0.69)</td>
+                <td>{ 13520, 34500 }</td>
               </tr>
 
               <tr>
-                <td>(0.150, 0.060)</td>
+                <td>(0.15, 0.06)</td>
                 <td>{ 7500, 3000 }</td>
               </tr>
-
             </table>
           </aside>
 
           <aside class="example">
-            Example <span class="chunk">mDCv</span> chunk mastering display white point for [[SRGB]]:
+            Example <span class="chunk">mDCv</span> chunk mastering display white point for [[Display-P3]]:
 
             <table id="mDCv-chunk-sdr-white-point-example" class="numbered simple">
               <tr>
@@ -3967,7 +3966,7 @@ with these exceptions:
 
           <aside class="example">
             Example <span class="chunk">mDCv</span> chunk mastering display maximum
-          luminance for [[SRGB]] <a>SDR</a>:
+          luminance for [[Display-P3]]:
             <table id="mDCv-chunk-sdr-max-luminance-example" class="numbered simple">
               <tr>
                 <th>Actual value</th>
@@ -3982,7 +3981,7 @@ with these exceptions:
           </aside>
 
           <aside class="example">
-            Example mDCv chunk mastering display minimum luminance for [[SRGB]] <a>SDR</a>:
+            Example mDCv chunk mastering display minimum luminance for [[Display-P3]]:
             <table id="mDCv-chunk-sdr-min-luminance-example" class="numbered simple">
               <tr>
                 <th>Actual value</th>


### PR DESCRIPTION
This PR makes a few changes to the mDCV chunk section of the spec.

Examples 9 through 12 are currently very specific to the TV industry and uses TV specific terminology. In essence, these examples hint at a TV broadcast specific profile of the use of the PNG format, rather than being useful information for PNG encoder or decoder implementers.  As such, these examples would be better placed in a document that describes how to use PNG, rather than in the PNG spec itself, which shouldn't imply any specific workflow.

So this PR replaces those examples with equivalent sRGB SDR examples, a format which is far more commonly used. It also address some of the terminology issues in #346.
