### PR TITLE
Improve wording in cICP section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3676,7 +3676,7 @@ with these exceptions:
           <p>Each of the fields of the <span class="chunk">cICP</span> chunk corresponds to the parameter of the same name in
           [[ITU-T-H.273]].</p>
 
-          <p>Currently only RGB is the supported color model in PNG, and as such <code>Matrix Coefficients</code> shall be set to <code>0</code>.</p>
+          <p>RGB is currently the only supported color model in PNG, and as such <code>Matrix Coefficients</code> shall be set to <code>0</code>.</p>
 
           <aside class="note">
             A <code>Matrix Coefficients</code> value other than <code>0</code> signals a transformation between colour difference


### PR DESCRIPTION
"Currently only RGB is the supported color model in PNG" was awkward phrasing.