### PR TITLE
Added unsigned integer examples for cICp Chunk

### DIFF
--- a/index.html
+++ b/index.html
@@ -3643,6 +3643,8 @@ with these exceptions:
           coefficients of the image using the code points specified in [[ITU-T-H.273]]. The video format signaling SHOULD be used
           when processing the image, including by a decoder or when rendering the image.</p>
 
+          <p>The cICp chunk consists of four 1-byte unsigned integers to identify the characterstics described above.</p>
+
           <p>The following specifies the syntax of the <span class="chunk">cICP</span> chunk:</p>
 
           <table id="cICP-chunk-syntax" class="numbered simple">
@@ -3728,20 +3730,14 @@ with these exceptions:
             </li>
           </ul>
 
-          <aside class="example">
-            <span class="chunk">cICP</span> chunk field values for a common sRGB <a>full-range image</a>:
-
-            <pre>
-  1 13 0 1
-  </pre>
-          </aside>
 
           <aside class="example">
             <span class="chunk">cICP</span> chunk field values for a <a>full-range image</a> that uses the colour primaries and the
             <a>PQ</a> <a>transfer function</a> specified at [[ITU-R-BT.2100]]:
 
             <pre>
-9 16 0 1
+9 16 0 1 (Decimal)
+09 10 00 01 (Four 1-byte unsigned integers)
 </pre>
           </aside>
 
@@ -3750,7 +3746,8 @@ with these exceptions:
             <a>HLG</a> <a>transfer function</a> specified at [[ITU-R-BT.2100]]:
 
             <pre>
-9 18 0 1
+9 18 0 1 (Decimal values)
+09 12 00 01 (Four 1-byte unsigned integers)
 </pre>
           </aside>
 
@@ -3759,7 +3756,8 @@ with these exceptions:
             that uses the colour primaries and the <a>transfer function</a> defined at [[ITU-R-BT.709]]:
 
             <pre>
-1 1 0 0
+1 1 0 0 (Decimal values)
+01 01 00 00 (Four 1-byte unsigned integers)
 </pre>
           </aside>
         </section>

--- a/index.html
+++ b/index.html
@@ -3643,7 +3643,7 @@ with these exceptions:
           coefficients of the image using the code points specified in [[ITU-T-H.273]]. The video format signaling SHOULD be used
           when processing the image, including by a decoder or when rendering the image.</p>
 
-          <p>The cICp chunk consists of four 1-byte unsigned integers to identify the characterstics described above.</p>
+          <p>The cICP chunk consists of four 1-byte unsigned integers to identify the characteristics described above.</p>
 
           <p>The following specifies the syntax of the <span class="chunk">cICP</span> chunk:</p>
 


### PR DESCRIPTION
This addresses some confusion we had while building the conformance files for cICp and removes the sRGB example that was unnecessary (it duplicates functions already existing in PNG)