### PR TITLE
Prefixed explanation of full-range PNG

### DIFF
--- a/index.html
+++ b/index.html
@@ -3689,7 +3689,8 @@ with these exceptions:
           <p>The <code>Video Full Range Flag</code> value MUST be either <code>0</code> or <code>1</code>.</p>
 
           <aside class="note">
-            If <code>Video Full Range Flag</code> value is <code>1</code>, then the image is a <a>full-range image</a>. The vast
+            If <code>Video Full Range Flag</code> value is <code>1</code>, then the image is a <a>full-range image</a>. Typically,
+            images in the RGB color representation are stored in the full-range signal quantization, therefore the vast
             majority of computer graphics and web images, including those used in traditional PNG workflows, are <a>full-range
             images</a>. If <code>Video Full Range Flag</code> value is <code>0</code>, then the image is a <a>narrow-range
             image</a>. Narrow range images are found in video workflows where the interpretation of sample values below reference


### PR DESCRIPTION
Added additional description for typical behavior. "RGB images are typically full-range"