### PR TITLE
better but still short luminance definition, fixes #406

### DIFF
--- a/index.html
+++ b/index.html
@@ -544,7 +544,7 @@ with these exceptions:
       </dt>
 
       <dd>
-        perceived brightness of a colour.
+        an objective measurement of the visible light intensity, taking into account the sensitivity of the human eye to different wavelengths. 
 
         <p class="note">Luminance and <a>chromaticity</a> together fully define a perceived colour. A formal definition of
         luminance is found at [[COLORIMETRY]].</p>

--- a/index.html
+++ b/index.html
@@ -546,8 +546,8 @@ with these exceptions:
       <dd>
         an objective measurement of the visible light intensity, taking into account the sensitivity of the human eye to different wavelengths. 
 
-        <p class="note">Luminance and <a>chromaticity</a> together fully define a perceived colour. A formal definition of
-        luminance is found at [[COLORIMETRY]].</p>
+        <p class="note">Luminance and <a>chromaticity</a> together fully define a perceived colour.  See <a href="https://colorusage.arc.nasa.gov/lum_and_chrom.php">Luminance and Chromaticity</a>
+        or, for a formal definition [[COLORIMETRY]].</p>
       </dd>
       <!-- Maintain a fragment named "3LZ77" to preserve incoming links to it -->
 


### PR DESCRIPTION
Better than the original definition (which was factually incorrect) while still pointing out the most important factor (it applies to visible wavelengths only and is weighted for human photopic vision; yellow green will have higher luminance that reds or blue-violets).

Trying to strike a balance between being correct, and being overwhelming with an over-long definition.