### PR TITLE
Clean up some "two links, same place", fix  #194

### DIFF
--- a/index.html
+++ b/index.html
@@ -2362,8 +2362,7 @@ with these exceptions:
     <section id="6AlphaRepresentation">
       <h2>Alpha representation</h2>
 
-      <p>In a PNG datastream transparency may be represented in one of four ways, depending on the PNG image type (see <a>alpha
-      separation</a> and <a>alpha compaction</a>).</p>
+      <p>In a PNG datastream transparency may be represented in one of four ways, depending on the PNG image type (see <a href="#3alphaSeparation"></a> and <a href="#3alphaCompaction"></a>).</p>
       <!-- <ol start="1"> -->
 
       <ol>
@@ -2498,7 +2497,7 @@ with these exceptions:
     <section class="introductory" id="8InterlaceIntro">
       <h3>Introduction</h3>
 
-      <p>Pass extraction (see <a href="#figure48">figure 4.8</a>) splits a PNG image into a sequence of reduced images (the
+      <p>Pass extraction (see <a href="#figure48">Figure 4.8</a>) splits a PNG image into a sequence of reduced images (the
       interlaced PNG image) where the first image defines a coarse view and subsequent images enhance this coarse view until the
       last image completes the PNG image. This allows progressive display of the interlaced PNG image by the decoder and allows
       images to "fade in" when they are being displayed on-the-fly. On average, interlacing slightly expands the datastream size,
@@ -2535,7 +2534,7 @@ with these exceptions:
       pass contains all of scanlines 1, 3, 5, etc. The transmission order is defined so that all the scanlines transmitted in a
       pass will have the same number of pixels; this is necessary for proper application of some of the filters. The interlaced PNG
       image consists of a sequence of seven reduced images. For example, if the PNG image is 16 by 16 pixels, then the third pass
-      will be a reduced image of two scanlines, each containing four pixels (see <a href="#figure48">figure 4.8</a>).</p>
+      will be a reduced image of two scanlines, each containing four pixels (see <a href="#figure48">Figure 4.8</a>).</p>
 
       <p>Scanlines that do not completely fill an integral number of bytes are padded as defined in <a href="#7Scanline"></a>.</p>
 
@@ -4368,8 +4367,7 @@ with these exceptions:
             </tr>
           </table>
 
-          <p>The keyword and null character are the same as in the <a class="chunk" href="#11tEXt">tEXt</a> chunk (see <a href=
-          "#11tEXt"></a>). The keyword is not compressed. The compression method entry defines the compression method used. The
+          <p>The keyword and null character are the same as in the <a class="chunk" href="#11tEXt">tEXt</a> chunk. The keyword is not compressed. The compression method entry defines the compression method used. The
           only value defined in this International Standard is 0 (<a>deflate</a> compression). Other values are reserved for future
           standardization. The compression method entry is followed by the compressed text datastream that makes up the remainder
           of the chunk. For compression method 0, this datastream is a <a>zlib</a> datastream with deflate compression (see


### PR DESCRIPTION
and use consistent section numbers in section links.

There were actually less of these than I thought. In general we use section links correctly. There were a couple using the wrong style, so there was no section number; I fixed them

There was only one where a chunk was linked twice, with both syntaxes.

We also have "see Figure xxx" and I regularized the case on a couple which said "See figure xxx".