### PR TITLE
Rephrase cLLi chunk description

### DIFF
--- a/index.html
+++ b/index.html
@@ -544,7 +544,7 @@ with these exceptions:
       </dt>
 
       <dd>
-        an objective measurement of the visible light intensity, taking into account the sensitivity of the human eye to different wavelengths. 
+        an objective measurement of the visible light intensity, taking into account the sensitivity of the human eye to different wavelengths.
 
         <p class="note">Luminance and <a>chromaticity</a> together fully define a perceived colour.  See <a href="https://colorusage.arc.nasa.gov/lum_and_chrom.php">Luminance and Chromaticity</a>
         or, for a formal definition [[COLORIMETRY]].</p>
@@ -3806,8 +3806,8 @@ with these exceptions:
           on a comparison of its inherent capabilities versus the original mastering display's capabilites.</p>
 
           <p>mDCv is typically used with the <a>PQ</a> [[ITU-R-BT.2100]] transfer function
-          and additional <a href="#cLLi-chunk">cLLI</a> metadata and is commonly then called <a>HDR10</a> (PQ with ST 2086 static metadata). 
-          The mDCv chunk may also be included with <a>HLG</a> [[ITU-R-BT.2100]] and <a>SDR</a> image formats (for example 
+          and additional <a href="#cLLi-chunk">cLLI</a> metadata and is commonly then called <a>HDR10</a> (PQ with ST 2086 static metadata).
+          The mDCv chunk may also be included with <a>HLG</a> [[ITU-R-BT.2100]] and <a>SDR</a> image formats (for example
           [[ITU-R-BT.709]]). </p>
 
           <p>Since mDCv was originally created as supplemental static metadata meant to
@@ -4069,13 +4069,13 @@ with these exceptions:
 <!-- 99 76 76 105 -->63 4C 4C 69
 </pre>
 
-          <p>If present, the <span class="chunk">cLLi</span> chunk identifies two characteristics of <a>HDR</a> content:</p>
-
-          <p>The <span class="chunk">cLLi</span> chunk adds static metadata which provides an opportunity
+          <p>If present, the <span class="chunk">cLLi</span> chunk adds static metadata for <a>HDR</a> content, which provides an opportunity
           to optimize tone mapping of the associated content for a target display. This is
           accomplished by tailoring the tone mapping of the content itself to the specific peak brightness
           capabilities of the target display to prevent clipping. This is most important for HDR image formats that use absolute
-          brightness values, such as <a>PQ</a>[ITU-R-BT.2100].  It may also be used with other image formats. </p>
+          brightness values, such as <a>PQ</a> [ITU-R-BT.2100]. It may also be used with other image formats.</p>
+
+          <p>The <span class="chunk">cLLi</span> chunk describes two characteristics of <a>HDR</a> content:</p>
 
           <p>MaxFALL (Maximum Frame Average Light Level) uses a static metadata value to indicate the
             maximum value of the <a>frame</a> average light level (in cd/m<sup>2</sup>, also known as nits)


### PR DESCRIPTION
This PR rephrases the cLLI chunk description. The current text has:

> If present, the cLLi chunk identifies two characteristics of HDR content:

which seems intended to be followed directly by the description of MaxFALL and MaxCLL. This PR reorders the paragraphs (with some slight rewording) to do that.