### PR TITLE
`eXIf` no longer at-risk

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,18 +320,7 @@ needs update, comment out for now
   <section id="sotd">
     <p>This specification is intended to become an International Standard, but is not yet one. It is inappropriate to refer to this
     specification as an International Standard.</p>
-    <p>The following features are at-risk and may be removed from this specification
-      if there is insufficient implementation support:</p>
-    <ul>
-      <li>The <a class="chunk" href="#eXIf">eXIf</a> chunk</li>
-    </ul>
-    <p>“At-risk” is a W3C Process term-of-art, and does not necessarily imply
-      that the feature is in danger of being dropped or delayed.
-      It means that the WG believes the feature may have difficulty being
-      interoperably implemented in a timely manner, and marking it as such
-      allows the WG to drop the feature if necessary when transitioning to the
-      Proposed Recommendation stage, without having to first publish a new
-      Candidate Recommendation without the feature.</p>
+
   </section>
   <!-- *********************************************************************
 


### PR DESCRIPTION
Because we have two passing implementations, Blink and WebKit