### PR TITLE
Space not allowed in bibref

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
           href: "https://poynton.ca/GammaFAQ.html",
           date: "1998-08-04"
         },
-        "HDR 10": {
+        "HDR10": {
           title: "HDR10 Media Profile",
           href: "https://en.wikipedia.org/wiki/HDR10"
         },


### PR DESCRIPTION
The HDR10 reference was failing because the bibliography entry called it HDR 10 (with a space) so it didn't match. Plus, spaces are not allowed there. So I fixed it by using HDR10.