### PR TITLE
Fix broken respec link in tRNS

### DIFF
--- a/index.html
+++ b/index.html
@@ -3202,7 +3202,7 @@ with these exceptions:
           is already present in those cases.</p>
 
           <p class="note">NOTE For 16-bit <a>greyscale</a> or <a>truecolor</a> data,
-          as described in <a href="13Sample-depth-rescaling"></a>,
+          as described in <a href="#13Sample-depth-rescaling"></a>,
           only <a href="#tRNS-compare-exactly">pixels matching the entire 16-bit values</a> in
           <span class="chunk">tRNS</span> chunks are transparent. Decoders have to postpone any sample depth rescaling until after
           the pixels have been tested for transparency.</p>


### PR DESCRIPTION
Spotted and fixed (missing "#") broken link