### PR TITLE
Link to IANA subtag registry, fix #429

### DIFF
--- a/index.html
+++ b/index.html
@@ -4453,7 +4453,9 @@ with these exceptions:
           uncompressed text, encoders shall set the compression method to 0, and decoders shall ignore it.</p>
 
           <p>The language tag is a well-formed language tag defined by [[BCP47]]. Unlike the keyword, the language tag is
-          case-insensitive. Subtags must appear in the IANA language subtag registry. If the language tag is empty, the language is
+          case-insensitive. Subtags must appear in the 
+          <a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">IANA language subtag registry</a>. 
+          If the language tag is empty, the language is
           unspecified. Examples of language tags include: <code>en</code>, <code>en-GB</code>, <code>es-419</code>,
           <code>zh-Hans</code>, <code>zh-Hans-CN</code>, <code>tlh-Cyrl-AQ</code>, <code>ar-AE-u-nu-latn</code>, and
           <code>x-private</code>.</p>


### PR DESCRIPTION
Added the link.

The document is a plain text registry with no apparent title, date etc so I just added a plain link rather than a bibliography entry.