### PR TITLE
Mark RP 2077 as Informative, fix #433

### DIFF
--- a/index.html
+++ b/index.html
@@ -3764,7 +3764,7 @@ with these exceptions:
             peak in order to preserve processing artifacts caused by filtering/compression or by uncontrolled lighting without
             clipping.  This can improve image quality during additional stages of processing and compression. The use of
             undershoot/overshoot has also been used to preserve additional color volume (both light and color) as described in
-            [[EBU-R-103]]. [[SMPTE-RP-2077]] describes full range in more detail and includes the mapping
+            [[EBU-R-103]]. [[?SMPTE-RP-2077]] describes full range in more detail and includes the mapping
             from <a>full-range images</a> to <a>narrow-range images</a>.  It also describes protected code values used for
             Serial Digital Interface (baseband video) carriage.
           </aside>


### PR DESCRIPTION
Resolved by making the non-free spec informative. EBU r103 is free, remains normative, and explains it well.