### PR TITLE
Add private bit depth and colour type fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -2311,6 +2311,12 @@ with these exceptions:
 
       <ul>
         <li>
+          bit depth
+        </li>
+        <li>
+          <a href="#3colourType">colour type</a>
+        </li>
+        <li>
           <a href="#10CompressionCM0">compression method</a>
         </li>
 


### PR DESCRIPTION
In Second Edition, all fields were allowed to have private values when the value was 128 or greater.

This shouldn't have been *all* fields, since some rely on values greater than 128 such as height and width.

Third Edition explicitly listed fields which could be private. Currently, it lists 3 of the 5 IHDR fields (ignoring width and height). However, those other two fields would be useful as private, too. Those fields are bit depth and colour type.

This commit adds those two fields to the list of explicitly allowed private fields.

Closes #446