### PR TITLE
Update changes section

### DIFF
--- a/index.html
+++ b/index.html
@@ -7615,7 +7615,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
     <h3 id="changes-20230921">Changes since the <a href="https://www.w3.org/TR/2023/CR-png-3-20230921/">Candidate Recommendation Snapshot of 21 September 2023 (Third Edition)</a></h3>
 
     <ul>
-      <!-- to 6 Jun 2024 -->
+      <!-- to 10 Jun 2024 -->
       <li>Added private bit depth and colour type fields</li>
       <li>Listed both decimal and hexadecimal values in MaxCLL and MaxFALL examples<li>
       <li>Corrected terminology in mDCv section</li>

--- a/index.html
+++ b/index.html
@@ -7615,7 +7615,25 @@ will need to be replaced by copies of lines 17-23, but processing background ins
     <h3 id="changes-20230921">Changes since the <a href="https://www.w3.org/TR/2023/CR-png-3-20230921/">Candidate Recommendation Snapshot of 21 September 2023 (Third Edition)</a></h3>
 
     <ul>
-      <!-- to 20 Feb 2024 -->
+      <!-- to 6 Jun 2024 -->
+      <li>Added private bit depth and colour type fields</li>
+      <li>Listed both decimal and hexadecimal values in MaxCLL and MaxFALL examples<li>
+      <li>Corrected terminology in mDCv section</li>
+      <li>Corrected "PNG image" in cHRM section</li>
+      <li>Consolidated color chunk precedence information</li>
+      <li>Added order of precedence for color space chunks</li>
+      <li>Clarified color chunk priorities description</li>
+      <li>Mark SMPTE RP 2077 as informative, since it is not freely available</li>
+      <li>Added color chunk priority table</li>
+      <li>Clarified alpha channels are always full-range</li>
+      <li>Added EOTF and OETF definitions</li>
+      <li>Added recommendation for handling negative values resulting from narrow-range images using an extended range transfer function</li>
+      <li>Clarified "video" from "video full range flag) is used to match H.273 wording but still applies to still images</li>
+      <li>Added link to IANA subtag registry</li>
+      <li>Fixed links to alhpa compaction and alpha separation sections</li>
+      <li>Fixed broken tRNS link</li>
+      <li>Added Display P3 cICP example</li>
+      <li>Changed "perceived" wording to "measured", as luminance and chromaticity don't define a perceived color</li>
       <li>Clarified which metadata forms part of HDR10</li>
       <li>Updated link to latest version of ITU-R BT.2390</li>
       <li>Noted that currently there is no published standard to adapt an SDR image from default viewing conditions (display luminance and ambient illumination) to those given in <span class="chunk">mDCV</span></li>


### PR DESCRIPTION
This is not quite ready to land. I went through all commits and added them to the changes section. However, several of the commits are adding the Implementation Report. One updates the PNG tools document. As those are separate documents, I don't think they should be listed in changes to the spec itself, right?

Also, this assumes https://github.com/w3c/PNG-spec/pull/387 and https://github.com/w3c/PNG-spec/pull/451 land. They haven't yet.

Once I know if separate document changes should be listed, I'll update this pull request to be in a ready-to-land state.