### PR TITLE
WPT now uses  macOS 14.5 so live tests pass

### DIFF
--- a/Implementation_Report_3e/index.html
+++ b/Implementation_Report_3e/index.html
@@ -48,7 +48,7 @@
                 <dt>Editor:</dt>
                 <dd>Chris Lilley</dd>
                 <dt>Last modified:</dt>
-                <dd>2024-03-28</dd>
+                <dd>2024-06-21</dd>
             </dl>
         </div>
         <main>
@@ -140,10 +140,10 @@
                     <table>
                         <tr class="header">
                             <th><a href="https://wpt.fyi/results/png/apng?label=experimental&label=master&aligned">Live Results</a></th>
-                            <th>Chrome 125</th>
-                            <th>Edge 124</th>
+                            <th>Chrome 128</th>
+                            <th>Edge 127</th>
                             <th>Firefox 126</th>
-                            <th>Safari TP 190</th>
+                            <th>Safari TP 196</th>
                         </tr>
                         <tr class="test">
                             <td class="testname">acTL-plays-one.html </td>
@@ -157,17 +157,17 @@
                             <td class="result passes-all"></td>
                             <td class="result passes-all"></td>
                             <td class="result passes-all"></td>
-                            <td class="result passes-none"></td>
+                            <td class="result passes-all"></td>
                         </tr>
                     </table>
 
                     <table>
                         <tr class="header">
                             <th>Manual tests</th>
-                            <th>Chrome 125</th>
-                            <th>Edge 124</th>
+                            <th>Chrome 128</th>
+                            <th>Edge 127</th>
                             <th>Firefox 126</th>
-                            <th>Safari TP 190</th>
+                            <th>Safari TP 196</th>
                         </tr>
                         <tr class="test">
                             <td class="testname">acTL-plays-one-manual.html </td>
@@ -199,17 +199,17 @@
                     <table>
                         <tr class="header">
                             <th><a href="https://wpt.fyi/results/png/apng?label=experimental&label=master&aligned">Live Results</a></th>
-                            <th>Chrome 125</th>
-                            <th>Edge 124</th>
+                            <th>Chrome 128</th>
+                            <th>Edge 127</th>
                             <th>Firefox 126</th>
-                            <th>Safari TP 190</th>
+                            <th>Safari TP 196</th>
                         </tr>
                         <tr class="test">
                             <td class="testname">fcTL-acTL-ordering.html </td>
                             <td class="result passes-all"></td>
                             <td class="result passes-all"></td>
                             <td class="result passes-all"></td>
-                            <td class="result passes-all"></td>
+                            <td class="result passes-none"></td>
                         </tr>
                         <tr class="test">
                             <td class="testname">fcTL-blend-over-repeatedly.html </td>
@@ -321,10 +321,10 @@
                     <table>
                         <tr class="header">
                             <th>Manual tests</th>
-                            <th>Chrome 125</th>
-                            <th>Edge 124</th>
+                            <th>Chrome 128</th>
+                            <th>Edge 127</th>
                             <th>Firefox 126</th>
-                            <th>Safari TP 190</th>
+                            <th>Safari TP 196</th>
                         </tr>
                         <tr class="test">
                             <td class="testname">fcTL-delay-16bit-manual.html </td>
@@ -369,10 +369,10 @@
                     <table>
                         <tr class="header">
                             <th><a href="https://wpt.fyi/results/png/apng?label=master&label=experimental&aligned&q=fdat">Live Results</a></th>
-                            <th>Chrome 125</th>
-                            <th>Edge 124</th>
+                            <th>Chrome 128</th>
+                            <th>Edge 127</th>
                             <th>Firefox 126</th>
-                            <th>Safari TP 190</th>
+                            <th>Safari TP 196</th>
                         </tr>
                         <tr class="test">
                             <td class="testname">fdAT-16bit.html </td>
@@ -421,7 +421,7 @@
                             <td class="result passes-all"></td>
                             <td class="result passes-all"></td>
                             <td class="result passes-none"></td>
-                            <td class="result passes-all"><a href="#note1">1</a></td>
+                            <td class="result passes-all"></td>
                         </tr>
                         <tr class="test">
                             <td class="testname">fdAT-split-basic.html </td>
@@ -438,9 +438,6 @@
                             <td class="result passes-all"></td>
                         </tr>
                     </table>
-                    <p class="note" id="note1">
-                        1. Passes on macOS 14 and above; WPT uses macOS 13.6 so test fails
-                    </p>
                 </section>
 
                 <section class="tests" id="APNG">
@@ -448,10 +445,10 @@
                     <table>
                         <tr class="header">
                             <th><a href="https://wpt.fyi/results/png/apng?label=experimental&label=master&aligned">Live Results</a></th>
-                            <th>Chrome 125</th>
-                            <th>Edge 124</th>
+                            <th>Chrome 128</th>
+                            <th>Edge 127</th>
                             <th>Firefox 126</th>
-                            <th>Safari TP 190</th>
+                            <th>Safari TP 196</th>
                         </tr>
                         <tr class="test">
                             <td class="testname">first-frame-IDAT.html </td>
@@ -472,10 +469,10 @@
                     <table>
                         <tr class="header">
                             <th><a href="https://wpt.fyi/results/apng?label=experimental&label=master&aligned">Live Results</a></th>
-                            <th>Chrome 125</th>
-                            <th>Edge 124</th>
+                            <th>Chrome 128</th>
+                            <th>Edge 127</th>
                             <th>Firefox 126</th>
-                            <th>Safari TP 190</th>
+                            <th>Safari TP 196</th>
                         </tr>
                         <tr class="test">
                             <td class="testname">animated-png-timeout.html  </td>
@@ -489,10 +486,10 @@
                     <table>
                         <tr class="header">
                             <th><a href="https://wpt.fyi/results/apng?label=experimental&label=master&aligned">Live Results</a></th>
-                            <th>Chrome 125</th>
-                            <th>Edge 124</th>
+                            <th>Chrome 128</th>
+                            <th>Edge 127</th>
                             <th>Firefox 126</th>
-                            <th>Safari TP 190</th>
+                            <th>Safari TP 196</th>
                         </tr>
                         <tr class="test">
                             <td class="testname">supported-in-source-type.html  </td>
@@ -566,46 +563,43 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/png/apng?label=experimental&label=master&aligned">Live Results</a></th>
-                                <th>Chrome 125</th>
-                                <th>Edge 124</th>
+                                <th>Chrome 128</th>
+                                <th>Edge 127</th>
                                 <th>Firefox 126</th>
-                                <th>Safari TP 190</th>
+                                <th>Safari TP 196</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">cicp-chunk.html </td>
                                 <td class="result passes-all"></td>
                                 <td class="result passes-all"></td>
                                 <td class="result passes-none"></td>
-                                <td class="result passes-all"><a href="#note2">2</a></td>
+                                <td class="result passes-all"></td>
                             </tr>
                             <tr class="test">
                                 <td class="testname">cICP-wins.html  </td>
                                 <td class="result passes-all"></td>
                                 <td class="result passes-all"></td>
                                 <td class="result passes-none"></td>
-                                <td class="result passes-all"><a href="#note2">2</a></td>
+                                <td class="result passes-all"></td>
                             </tr>
                         </table>
                         <h3>CICP in APNG tests</h3>
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/png/apng/fDAT-inherits-cICP.html?label=experimental&label=master&aligned">Live Results</a></th>
-                                <th>Chrome 125</th>
-                                <th>Edge 124</th>
+                                <th>Chrome 128</th>
+                                <th>Edge 127</th>
                                 <th>Firefox 126</th>
-                                <th>Safari TP 190</th>
+                                <th>Safari TP 196</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">fDAT-inherits-cICP.html</td>
                                 <td class="result passes-all"></td>
                                 <td class="result passes-all"></td>
                                 <td class="result passes-none"></td>
-                                <td class="result passes-all"><a href="#note2">2</a></td>
+                                <td class="result passes-all"></td>
                             </tr>
                         </table>
-                        <p class="note" id="note2">
-                            2. Passes on macOS 14 and above; WPT uses macOS 13.6 so test fails
-                        </p>
                     </section>
                 </section>
 
@@ -624,30 +618,27 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/png/cICP-wins.html?label=experimental&label=master&aligned">Live Results</a></th>
-                                <th>Chrome 125</th>
-                                <th>Edge 124</th>
+                                <th>Chrome 128</th>
+                                <th>Edge 127</th>
                                 <th>Firefox 126</th>
-                                <th>Safari TP 190</th>
+                                <th>Safari TP 196</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">cICP-wins.html </td>
                                 <td class="result passes-all"></td>
                                 <td class="result passes-all"></td>
                                 <td class="result passes-none"></td>
-                                <td class="result passes-all"><a href="#note3">3</a></td>
+                                <td class="result passes-all"></td>
                             </tr>
                         </table>
-                        <p class="note" id="note3">
-                            3. Passes on macOS 14 and above; WPT uses macOS 13.6 so test fails
-                        </p>
                         <h3>iCCP wins over sRGB</h3>
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/css/css-color/tagged-images-004.html?label=experimental&label=master&aligned">Live Results</a></th>
-                                <th>Chrome 125</th>
-                                <th>Edge 124</th>
+                                <th>Chrome 128</th>
+                                <th>Edge 127</th>
                                 <th>Firefox 126</th>
-                                <th>Safari TP 190</th>
+                                <th>Safari TP 196</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">tagged-images-004.html </td>
@@ -777,10 +768,10 @@
                             <tr class="header">
                                 <th><a href="https://svgees.us/PNG/iCCP/tests.html">Manual tests</a> 
                                 (<a href="https://svgees.us/PNG/iCCP/results.html">Archived results</a>)  </th>
-                                <th>Chrome 125</th>
-                                <th>Edge 124</th>
+                                <th>Chrome 128</th>
+                                <th>Edge 127</th>
                                 <th>Firefox 126</th>
-                                <th>Safari TP 190</th>
+                                <th>Safari TP 196</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">'sRGB' chunk, relative colorimetric intent</td>
@@ -802,10 +793,10 @@
                             <tr class="header">
                                 <th><a href="https://svgees.us/PNG/iCCP/tests.html">Manual tests</a> 
                                 (<a href="https://svgees.us/PNG/iCCP/results.html">Archived results</a>)  </th>
-                                <th>Chrome 125</th>
-                                <th>Edge 124</th>
+                                <th>Chrome 128</th>
+                                <th>Edge 127</th>
                                 <th>Firefox 126</th>
-                                <th>Safari TP 190</th>
+                                <th>Safari TP 196</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">sRGB with red and green colorants swapped</td>
@@ -834,10 +825,10 @@
                             <tr class="header">
                                 <th><a href="https://svgees.us/PNG/iCCP/tests.html">Manual tests</a> 
                                 (<a href="https://svgees.us/PNG/iCCP/results.html">Archived results</a>)  </th>
-                                <th>Chrome 125</th>
-                                <th>Edge 124</th>
+                                <th>Chrome 128</th>
+                                <th>Edge 127</th>
                                 <th>Firefox 126</th>
-                                <th>Safari TP 190</th>
+                                <th>Safari TP 196</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">CIE RGB, L* TRC</td>
@@ -900,10 +891,10 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/png?label=master&label=experimental&aligned&q=exif">Live Results</a></th>
-                                <th>Chrome 125</th>
-                                <th>Edge 124</th>
+                                <th>Chrome 128</th>
+                                <th>Edge 127</th>
                                 <th>Firefox 126</th>
-                                <th>Safari TP 190</th>
+                                <th>Safari TP 196</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">exif-chunk.html  </td>
@@ -917,10 +908,10 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/css/css-images/image-orientation/image-orientation-from-image.html?label=experimental&label=master&aligned">Live Results</a></th>
-                                <th>Chrome 125</th>
-                                <th>Edge 124</th>
+                                <th>Chrome 128</th>
+                                <th>Edge 127</th>
                                 <th>Firefox 126</th>
-                                <th>Safari TP 190</th>
+                                <th>Safari TP 196</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">image-orientation-from-image.html </td>
@@ -933,10 +924,10 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/css/css-images/image-orientation/image-orientation-from-image-embedded-content.html?label=experimental&label=master&aligned">Live Results</a></th>
-                                <th>Chrome 125</th>
-                                <th>Edge 124</th>
+                                <th>Chrome 128</th>
+                                <th>Edge 127</th>
                                 <th>Firefox 126</th>
-                                <th>Safari TP 190</th>
+                                <th>Safari TP 196</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">image-orientation-from-image-embedded-content.html </td>
@@ -950,10 +941,10 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/css/css-images/image-orientation/image-orientation-exif-png.html?label=experimental&label=master&aligned">Live Results</a></th>
-                                <th>Chrome 125</th>
-                                <th>Edge 124</th>
+                                <th>Chrome 128</th>
+                                <th>Edge 127</th>
                                 <th>Firefox 126</th>
-                                <th>Safari TP 190</th>
+                                <th>Safari TP 196</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">image-orientation-exif-png.html </td>
@@ -989,10 +980,10 @@
                             <table>
                                 <tr class="header">
                                     <th><a href="https://wpt.fyi/results/png/trns-chunk.html?label=experimental&label=master&aligned">Live Results</a></th>
-                                    <th>Chrome 125</th>
-                                    <th>Edge 124</th>
+                                    <th>Chrome 128</th>
+                                    <th>Edge 127</th>
                                     <th>Firefox 126</th>
-                                    <th>Safari TP 190</th>
+                                    <th>Safari TP 196</th>
                                 </tr>
                                 <tr class="test">
                                     <td class="testname">trns-chunk.html</td>
@@ -1021,10 +1012,10 @@
                             <table>
                                 <tr class="header">
                                     <th><a href="https://wpt.fyi/results/png/errors?label=experimental&label=master&aligned">Live Results</a></th>
-                                    <th>Chrome 125</th>
-                                    <th>Edge 124</th>
+                                    <th>Chrome 128</th>
+                                    <th>Edge 127</th>
                                     <th>Firefox 126</th>
-                                    <th>Safari TP 190</th>
+                                    <th>Safari TP 196</th>
                                 </tr>
                                 <tr class="test">
                                     <td class="testname">unknown-ancillary-error-recovery.html </td>


### PR DESCRIPTION
The implementation report used to have special pleading that some tests in Safari would pass, if only wpt was running macOS 14 instead of 13.6. This is no longer needed because WPT is now running macOS 14.5.

Also updated browser versions to current WPT ones.

Also fixed an error (one failing test was incorrectly shown in the table as the preceding test, my bad)