### PR TITLE
Colour in images, fix #374

### DIFF
--- a/figures/indexed-colour-image.svg
+++ b/figures/indexed-colour-image.svg
@@ -173,7 +173,7 @@ text {
 
 
 <g style="stroke:none; font-size:18px; text-anchor:middle">
-	<text x="80" y="20">Indexed colour</text>
+	<text x="80" y="20">Indexed color</text>
 	<text x="80" y="40">image data</text>
 	<text x="480" y="20">Palette</text>
 	<text x="580" y="20">Alpha</text>

--- a/figures/possible-pixel-types.svg
+++ b/figures/possible-pixel-types.svg
@@ -25,7 +25,7 @@ text {
 
 <!-- image types -->
 
-<!-- truecolour with alpha -->
+<!-- truecolor with alpha -->
 
 <rect x="20" y="60" width="20" height="20"  style="stroke:black;stroke-width:1;;fill:#B88" />
 <text x="25" y="75">R</text>
@@ -42,7 +42,7 @@ text {
 <rect x="40" y="120" width="20" height="20"  style="stroke:black;stroke-width:1;;fill:white" />
 <text x="45" y="135">A</text>
 
-<!-- truecolour -->
+<!-- truecolor -->
 <rect x="20" y="180" width="20" height="20"  style="stroke:black;stroke-width:1;;fill:#B88" />
 <text x="25" y="195">R</text>
 <rect x="40" y="180" width="20" height="20"  style="stroke:black;stroke-width:1;;fill:#8B8" />
@@ -54,7 +54,7 @@ text {
 <rect x="20" y="240" width="20" height="20"  style="stroke:black;stroke-width:1;fill:#AAA" />
 <text x="25" y="255">Y</text>
 
-<!-- indexed colour -->
+<!-- indexed color -->
 <rect x="20" y="300" width="20" height="20"  style="stroke:black;stroke-width:1;fill:#ACA" />
 <text x="25" y="315">3</text>
 
@@ -169,11 +169,11 @@ text {
 </g>
 
 <g style="font-size:16px; text-anchor:start">
-	<text x="20" y="54">Truecolour with alpha</text>
+	<text x="20" y="54">Truecolor with alpha</text>
   	<text x="20" y="114">Greyscale with alpha</text>
-	<text x="20" y="174">Truecolour</text>
+	<text x="20" y="174">Truecolor</text>
 	<text x="20" y="234">Greyscale</text>
-	<text x="20" y="294">Indexed colour</text>
+	<text x="20" y="294">Indexed color</text>
 
 </g>
 

--- a/index.html
+++ b/index.html
@@ -539,7 +539,7 @@ with these exceptions:
       <dd>
         an objective measurement of the visible light intensity, taking into account the sensitivity of the human eye to different wavelengths.
 
-        <p class="note">Luminance and <a>chromaticity</a> together fully define a measured colour.  See <a href="https://colorusage.arc.nasa.gov/lum_and_chrom.php">Luminance and Chromaticity</a>
+        <p class="note">Luminance and <a>chromaticity</a> together fully define a measured color.  See <a href="https://colorusage.arc.nasa.gov/lum_and_chrom.php">Luminance and Chromaticity</a>
         or, for a formal definition [[COLORIMETRY]].</p>
 
       </dd>
@@ -2314,7 +2314,7 @@ with these exceptions:
           bit depth
         </li>
         <li>
-          <a href="#3colourType">colour type</a>
+          <a href="#3colourType">color type</a>
         </li>
         <li>
           <a href="#10CompressionCM0">compression method</a>
@@ -7616,7 +7616,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
 
     <ul>
       <!-- to 10 Jun 2024 -->
-      <li>Added private bit depth and colour type fields</li>
+      <li>Clarified that bit depth and color type fields can take private values</li>
       <li>Listed both decimal and hexadecimal values in MaxCLL and MaxFALL examples<li>
       <li>Corrected terminology in mDCv section</li>
       <li>Corrected "PNG image" in cHRM section</li>


### PR DESCRIPTION
An earlier pull request changed human-visible colour to color in index.html {preserving second edition links that use colour)
  https://github.com/w3c/PNG-spec/pull/411/files

However:
 - the svg images still used the colour spelling
 - a couple more usages of colour have crept back since
 
Now fixed by this PR.

Also, the change log about private color type values could have been read as a new feature; I reworded it to be a clarification.