### PR TITLE
`mDCV` erratum #539

### DIFF
--- a/REC-PNG-20250624-errata.html
+++ b/REC-PNG-20250624-errata.html
@@ -43,7 +43,33 @@ https://www.w3.org/TR/2025/REC-png-3-20250624/</a>
     Please raise them as <a href="https://github.com/w3c/png/issues?q=is%3Aissue%20state%3Aopen%20milestone%3A%223rd%20edition%22">issues on GitHub</a> .</p>
 <hr />
 
-<p><em>None</em></p>
+<div class="erratum" id="err-mDCV-values">
+    <h2>Incorrect values in mDCV example</h2>
+    <dl>
+        <dt>Category:</dt>
+        <dd><a href="https://www.w3.org/2020/Process-20200915/#correction-classes">
+        2. Corrections that do not affect conformance</a></dd>
+        <dt>Date:</dt>
+        <dd>10 September 2025</dd>
+        <dt>Reported by:</dt>
+        <dd><a href="https://github.com/w3c/png/issues/539">Christopher Cameron</a></dd>
+        <dt>Status:</dt>
+        <dd>Proposed</dd>
+    </dl>
+    <h3>Description</h3>
+    <p>The hexadecimal values for the decimal value of the x chromaticity white point are incorrect.
+    </p>
+    <h3>Change</h3>
+    <p> in <a href="https://www.w3.org/TR/png-3/#example-6">Example 6</a>, change the text: </p>
+    <div class="old">
+    Stored Hexadecimal values: {3C 05, 40 42}
+    </div>
+    <p>to</p>
+    <div class="new">
+    Stored Hexadecimal values: {3D 13, 40 42}
+    </div>
+</div>
+
 <!--
 <div class="erratum" id="err-">
     <h2></h2>

--- a/REC-PNG-20250624-errata.html
+++ b/REC-PNG-20250624-errata.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+        <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>Errata in PNG Recommendation, Third Edition</title>
+        <style type="text/css">
+        .changed {background: yellow; padding: 2px}
+        div.old, div.new {background: #DDF; padding: 4px; border: thin solid #AAF}
+        </style>
+        <link rel="stylesheet" type="text/css" href="http://www.w3.org/StyleSheets/TR/base" />
+        </head>
+<body>
+<div class="head">
+<a href="http://www.w3.org/">
+<img src= "http://www.w3.org/Icons/w3c_home" alt="W3C" height="48" width= "72" />
+</a>
+<!-- ############################################################# -->
+<h1>PNG Recommendation, Third Edition Errata</h1>
+<dl>
+<dt>This version:</dt>
+<dd>
+<a href="http://www.w3.org/2025/06/REC-PNG-20250624-errata">
+http://www.w3.org/2025/06/REC-PNG-20250624-errata</a>
+</dd>
+<dt>Last modified:</dt>
+<dd>$Date: 2025/06/12 00:11:00 $</dd>
+</dl>
+<dl>
+<dt>This document records known errors in the document:</dt>
+<dd>
+<a href="https://www.w3.org/TR/2025/REC-png-3-20250624/">
+https://www.w3.org/TR/2025/REC-png-3-20250624/</a>
+</dd>
+<dt>The latest version of the PNG specification is at:</dt>
+<dd>
+<a href="http://www.w3.org/TR/PNG/">http://www.w3.org/TR/PNG</a>
+</dd>
+</dl>
+<!-- ############################################################# -->
+<hr />
+</div>
+<p>Public comments on this W3C Recommendation are welcome.
+    Please raise them as <a href="https://github.com/w3c/png/issues?q=is%3Aissue%20state%3Aopen%20milestone%3A%223rd%20edition%22">issues on GitHub</a> .</p>
+<hr />
+
+<p><em>None</em></p>
+<!--
+<div class="erratum" id="err-">
+    <h2></h2>
+    <dl>
+        <dt>Category:</dt>
+        <dd><a href="https://www.w3.org/2020/Process-20200915/#correction-classes">
+        2. Corrections that do not affect conformance</a></dd>
+        <dt>Date:</dt>
+        <dd></dd>
+        <dt>Reported by:</dt>
+        <dd><a href=""></a></dd>
+        <dt>Status:</dt>
+        <dd>Proposed</dd>
+    </dl>
+    <h3>Description</h3>
+    <p>
+    </p>
+    <h3>Change</h3>
+    <p> in <a href=""></a>, change the text in []: </p>
+    <div class="old">
+
+    </div>
+    <p>to</p>
+    <div class="new">
+
+    </div>
+</div>
+-->
+<address><a href="mailto:chris@w3.org">Chris Lilley</a></address>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4029,7 +4029,7 @@ with these exceptions:
                 <td>Illuminant D65 specified in [[SMPTE-RP-177]]</td>
                 <td>(0.3127, 0.3290)</td>
                 <td>{ 15635, 16450 }</td>
-                <td>{ 3C 05, 40 42 }</td>
+                <td>{ 3D 13, 40 42 }</td>
               </tr>
             </table>
           </aside>
@@ -7658,6 +7658,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
     <h3 id="changes-20250624">Changes since the <a href="https://www.w3.org/TR/2025/REC-png-3-20250624/">W3C Recommendation of 24 June 2025</a></h3>
 
     <ul>
+      <li>Corrected a typo in an 'mDCV' example</li>
       <li>Updated 'cHRM' chromaticities to use PNG four-byte signed integers, to enble ultra-wide gamut color spaces. Previously, negative values were not representable.
       (<a href="https://github.com/w3c/png/issues/527">Issue 527</a>)
       </li>


### PR DESCRIPTION
Adds to the Third Edition errata document, and corrects in Fourth Edition Editors Draft