### PR TITLE
Fix typos in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -5081,7 +5081,7 @@ with these exceptions:
           <p>The <span class="chunk">acTL</span> chunk must appear before the first <a class="chunk" href="#11IDAT">IDAT</a> chunk
           within a valid PNG stream.</p>
 
-          <p class="note">For Web compatibility, due to the long time between the development and deployment of this chunk and it's
+          <p class="note">For Web compatibility, due to the long time between the development and deployment of this chunk and its
           incorporation into the PNG specification, this chunk name is exceptionally defined as if it were a private chunk.</p>
         </section>
 
@@ -5265,7 +5265,7 @@ with these exceptions:
    a "byte" shall be an 8-bit unsigned integer with the range 0 to (2^8)-1
  -->
 
-          <p class="note">For Web compatibility, due to the long time between the development and deployment of this chunk and it's
+          <p class="note">For Web compatibility, due to the long time between the development and deployment of this chunk and its
           incorporation into the PNG specification, this chunk name is exceptionally defined as if it were a private chunk.</p>
         </section>
 
@@ -5329,7 +5329,7 @@ with these exceptions:
           `y_offset` values must be scaled in the same way as the main image. Conceptually, such scaling occurs while mapping the
           output buffer onto the <a>canvas</a>.</p>
 
-          <p class="note">For Web compatibility, due to the long time between the development and deployment of this chunk and it's
+          <p class="note">For Web compatibility, due to the long time between the development and deployment of this chunk and its
           incorporation into the PNG specification, this chunk name is exceptionally defined as if it were a private chunk.</p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -5094,7 +5094,7 @@ with these exceptions:
     <!-- 102 99 84 76 -->66 63 54 4C
     </pre>
           <p>The <span class="chunk">fcTL</span> chunk defines the dimensions, position, delay and disposal of an individual frame.
-          Exactly one <span class="chunk">fcTL</span> chunk chunk is required for each frame. It contains:</p>
+          Exactly one <span class="chunk">fcTL</span> chunk is required for each frame. It contains:</p>
 
           <table id="fcTL-structure" class="numbered simple">
             <caption>
@@ -5168,7 +5168,7 @@ with these exceptions:
 
           <p>`delay_num` and `delay_den` define the numerator and denominator of the delay fraction; indicating the time to display
           the current frame, in seconds. If the denominator is 0, it is to be treated as if it were 100 (that is, `delay_num` then
-          specifies 1/100ths of a second). If the the value of the numerator is 0 the decoder should render the next frame as
+          specifies 1/100ths of a second). If the value of the numerator is 0 the decoder should render the next frame as
           quickly as possible, though viewers may impose a reasonable lower bound. They are encoded as two-byte unsigned
           integers.</p>
 


### PR DESCRIPTION
The words "chunk" and "the" are duplicated in two sentences.
Also fix "it's" vs "its" typos.