### PR TITLE
Fix incorrect numbers in example 9, #567

### DIFF
--- a/index.html
+++ b/index.html
@@ -4128,8 +4128,8 @@ with these exceptions:
 
               <tr>
                 <td>(0.265, 0.69)</td>
-                <td>{ 13520, 34500 }</td>
-                <td>{ 34 D0, 86 C4 }</td>
+                <td>{ 13250, 34500 }</td>
+                <td>{ 33 C2, 86 C4 }</td>
               </tr>
 
               <tr>


### PR DESCRIPTION
There was a typo in the chromaticity coordinate, then carried forward to the hex values.

Checked against the [Display P3 official definition](https://registry.color.org/rgb-registry/displayp3)