### PR TITLE
Add chunk for HDR Reference White level, fix #390

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,18 +179,20 @@
         "ITU-R-BT.2020": {
           title: "Parameter values for ultra-high definition television systems for production and international programme exchange",
           publisher: "ITU",
+          date: "2015-10",
           href: "https://www.itu.int/rec/R-REC-BT.2020"
         },
         "ITU-R-BT.2100": {
           title: "ITU-R BT.2100, SERIES BT: BROADCASTING SERVICE (TELEVISION). Image parameter values for high dynamic range television for use in production and international programme exchange",
           publisher: "ITU",
-          date: "2018-07",
+          date: "2025-02-05",
           href: "https://www.itu.int/rec/R-REC-BT.2100"
         },
         "ITU-R-BT.2390": {
           title: "High dynamic range television for production and international programme exchange",
           publisher: "ITU",
-          href: "https://www.itu.int/dms_pub/itu-r/opb/rep/R-REP-BT.2390-11-2023-PDF-E.pdf"
+          date: "2025-03",
+          href: "https://www.itu.int/pub/R-REP-BT.2390-12-2025"
         },
         "ITU-R-BT.2408-9": {
             title: "Guidelines for operational practices in high dynamic range television production",

--- a/index.html
+++ b/index.html
@@ -4354,6 +4354,12 @@ with these exceptions:
           as is used in [[ISO_22028-5]].
         </p>
 
+        <p class="note">As HLG is a relative system, the value of 203 cd/m<sup>2</sup> 
+          is only correct when viewed under reference viewing conditions
+          on a 1000 cd/m<sup>2</sup> monitor.
+          With other screen brightnesses and under different viewing conditions, 
+          this value can be expected to change.</p>
+
         <p>Previously, it was not possible to indicate
           that the content was mastered to some other reference level,
           such as 100 cd/m<sup>2</sup>.

--- a/index.html
+++ b/index.html
@@ -2054,6 +2054,16 @@ with these exceptions:
 
         <tr>
           <td>
+            <a class="chunk" href="#hRWl-chunk">hRWl</a>
+          </td>
+          <td>No</td>
+          <td>
+            Before <a class="chunk" href="#11PLTE">PLTE</a> and <a class="chunk" href="#11IDAT">IDAT</a>.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             <a class="chunk" href="#11sBIT">sBIT</a>
           </td>
           <td>No</td>
@@ -4315,45 +4325,44 @@ with these exceptions:
             </table>
           </aside>
         </section>
-      </section>
 
-      <section id="hRWl-chunk">
-          <h2><span class="chunk">hRWl</span> HDR Reference White Level</h2>
-          <p>The four-byte chunk type field contains the hexadecimal values</p>
+        <section id="hRWl-chunk">
+            <h2><span class="chunk">hRWl</span> HDR Reference White Level</h2>
+            <p>The four-byte chunk type field contains the hexadecimal values</p>
 
           <pre>
 68 52 57 6C
 </pre>
 
-      <p>If present, the <span class="chunk">hRWl</span> chunk identifies a characteristic of <a>HDR</a> content.It adds static metadata which is helpful when compositing a mix of HDR and SDR content.</p>
+        <p>If present, the <span class="chunk">hRWl</span> chunk identifies a characteristic of <a>HDR</a> content.It adds static metadata which is helpful when compositing a mix of HDR and SDR content.</p>
 
-      <p>It is standard practice,
-        defined in [[ITU-R-BT.2408-9]] section 2.1,
-        to author HDR content
-        such that HDR Reference White has a luminance level of 
-        203 cd/m<sup>2</sup> (also known as nits).
-        This corresponds to a code value of 58% in PQ
-        and 75% in HLG on a 1000 cd/m<sup>2</sup> display.
-        This value is assumed in various workflows
-        such as compositing or HDR to SDR content conversion.
-      </p>
+        <p>It is standard practice,
+          defined in [[ITU-R-BT.2408-9]] section 2.1,
+          to author HDR content
+          such that HDR Reference White has a luminance level of 
+          203 cd/m<sup>2</sup> (also known as nits).
+          This corresponds to a code value of 58% in PQ
+          and 75% in HLG on a 1000 cd/m<sup>2</sup> display.
+          This value is assumed in various workflows
+          such as compositing, or HDR to SDR content conversion.
+        </p>
 
-      <p class="note">This is the same definition,
-        and the same standard value,
-        as is used in [[ISO_22028-5]].
-      </p>
+        <p class="note">This is the same definition,
+          and the same standard value,
+          as is used in [[ISO_22028-5]].
+        </p>
 
-      <p>Previously, it was not possible to indicate
-        that the content was mastered to some other reference level,
-        such as 100 cd/m<sup>2</sup>.
-      </p>
+        <p>Previously, it was not possible to indicate
+          that the content was mastered to some other reference level,
+          such as 100 cd/m<sup>2</sup>.
+        </p>
 
-      <p>The <span class="chunk">hRWl</span> chunk
+        <p>The <span class="chunk">hRWl</span> chunk
       indicates that HDR Reference White uses non-standard luminance level.</p>
 
-      <p>The value is encoded as a <a>PNG four-byte unsigned integer</a>.</p>
+        <p>The value is encoded as a <a>PNG four-byte unsigned integer</a>.</p>
 
-      <p>The following specifies the syntax of the <span class="chunk">hRWl</span> chunk:</p>
+        <p>The following specifies the syntax of the <span class="chunk">hRWl</span> chunk:</p>
 
            <table id="hRWl-chunk-syntax" class="numbered simple">
              <caption>hRWl chunk components</caption>
@@ -4397,6 +4406,7 @@ with these exceptions:
           if the chunk is absent.
         </p>
 
+      </section>
     </section>
 
 

--- a/index.html
+++ b/index.html
@@ -4334,7 +4334,7 @@ with these exceptions:
 68 52 57 6C
 </pre>
 
-        <p>If present, the <span class="chunk">hRWl</span> chunk identifies a characteristic of <a>HDR</a> content.It adds static metadata which is helpful when compositing a mix of HDR and SDR content.</p>
+        <p>If present, the <span class="chunk">hRWl</span> chunk identifies a characteristic of <a>HDR</a> content. It adds static metadata which is helpful when compositing a mix of HDR and SDR content.</p>
 
         <p>It is standard practice,
           defined in [[ITU-R-BT.2408-9]] section 2.1,

--- a/index.html
+++ b/index.html
@@ -2056,7 +2056,7 @@ with these exceptions:
 
         <tr>
           <td>
-            <a class="chunk" href="#hRWl-chunk">hRWl</a>
+            <a class="chunk" href="#hRWL-chunk">hRWL</a>
           </td>
           <td>No</td>
           <td>
@@ -4328,15 +4328,15 @@ with these exceptions:
           </aside>
         </section>
 
-        <section id="hRWl-chunk">
-            <h2><span class="chunk">hRWl</span> HDR Reference White Level</h2>
+        <section id="hRWL-chunk">
+            <h2><span class="chunk">hRWL</span> HDR Reference White Level</h2>
             <p>The four-byte chunk type field contains the hexadecimal values</p>
 
           <pre>
-68 52 57 6C
+68 52 57 4C
 </pre>
 
-        <p>If present, the <span class="chunk">hRWl</span> chunk identifies a characteristic of <a>HDR</a> content. It adds static metadata which is helpful when compositing a mix of HDR and SDR content.</p>
+        <p>If present, the <span class="chunk">hRWL</span> chunk identifies a characteristic of <a>HDR</a> content. It adds static metadata which is helpful when compositing a mix of HDR and SDR content.</p>
 
         <p>It is standard practice,
           defined in [[ITU-R-BT.2408-9]] section 2.1,
@@ -4365,15 +4365,15 @@ with these exceptions:
           such as 100 cd/m<sup>2</sup>.
         </p>
 
-        <p>The <span class="chunk">hRWl</span> chunk
+        <p>The <span class="chunk">hRWL</span> chunk
       indicates that HDR Reference White uses non-standard luminance level.</p>
 
         <p>The value is encoded as a <a>PNG four-byte unsigned integer</a>.</p>
 
-        <p>The following specifies the syntax of the <span class="chunk">hRWl</span> chunk:</p>
+        <p>The following specifies the syntax of the <span class="chunk">hRWL</span> chunk:</p>
 
-           <table id="hRWl-chunk-syntax" class="numbered simple">
-             <caption>hRWl chunk components</caption>
+           <table id="hRWL-chunk-syntax" class="numbered simple">
+             <caption>hRWL chunk components</caption>
 
              <tr>
                <th>Name</th>
@@ -4382,16 +4382,16 @@ with these exceptions:
              </tr>
 
              <tr>
-               <td>HDR Reference White level</td>
+               <td>HDR Reference White Level</td>
                <td>4 bytes</td>
                <td>0.0001 cd/m<sup>2</sup></td>
              </tr>
            </table>
 
            <aside class="example">
-             Example <span class="chunk">hRWl</span> chunk HDR Reference White Level:
+             Example <span class="chunk">hRWL</span> chunk HDR Reference White Level:
 
-             <table id="hRWl-chunk-white-level-example" class="numbered simple">
+             <table id="hRWL-chunk-white-level-example" class="numbered simple">
                <tr>
                  <th>Actual value</th>
                  <th>Stored Decimal value</th>
@@ -4408,7 +4408,7 @@ with these exceptions:
 
           <p>If the standard value of 203 cd/m<sup>2</sup>
           has been used,
-          the <span class="chunk">hRWl</span> chunk
+          the <span class="chunk">hRWL</span> chunk
           should <strong>not</strong> be added. 
           The default, standard value will be assumed
           if the chunk is absent.

--- a/index.html
+++ b/index.html
@@ -164,6 +164,12 @@
           date: "2019-02",
           publisher: "ISO"
         },
+        "ISO_22028-5": {
+          title: "Photography and graphic technology — Extended colour encodings for digital image storage, manipulation and interchange. Part 5: High dynamic range and wide colour gamut encoding for still images (HDR/WCG)",
+          publisher: "ISO",
+          date: "2026-05",
+          href: "https://www.iso.org/standard/87778.html"
+        },
         "ITU-R-BT.709": {
           title: "ITU-R BT.709, SERIES BT: BROADCASTING SERVICE (TELEVISION). Parameter values for the HDTV standards for production and international programme exchange",
           publisher: "ITU",
@@ -181,10 +187,16 @@
           date: "2018-07",
           href: "https://www.itu.int/rec/R-REC-BT.2100"
         },
-          "ITU-R-BT.2390": {
+        "ITU-R-BT.2390": {
           title: "High dynamic range television for production and international programme exchange",
           publisher: "ITU",
           href: "https://www.itu.int/dms_pub/itu-r/opb/rep/R-REP-BT.2390-11-2023-PDF-E.pdf"
+        },
+        "ITU-R-BT.2408-9": {
+            title: "Guidelines for operational practices in high dynamic range television production",
+            publisher: "ITU",
+            date: "2026-03",
+            href: "https://www.itu.int/pub/R-REP-BT.2408-9-2026"
         },
         "ITU-T-H.273": {
           title: "ITU-T H.273, SERIES H: AUDIOVISUAL AND MULTIMEDIA SYSTEMS Infrastructure of audiovisual services – Coding of moving video. Coding-independent code points for video signal type identification",
@@ -4304,6 +4316,88 @@ with these exceptions:
           </aside>
         </section>
       </section>
+
+      <section id="hRWl-chunk">
+          <h2><span class="chunk">hRWl</span> HDR Reference White Level</h2>
+          <p>The four-byte chunk type field contains the hexadecimal values</p>
+
+          <pre>
+68 52 57 6C
+</pre>
+
+      <p>If present, the <span class="chunk">hRWl</span> chunk identifies a characteristic of <a>HDR</a> content.It adds static metadata which is helpful when compositing a mix of HDR and SDR content.</p>
+
+      <p>It is standard practice,
+        defined in [[ITU-R-BT.2408-9]] section 2.1,
+        to author HDR content
+        such that HDR Reference White has a luminance level of 
+        203 cd/m<sup>2</sup> (also known as nits).
+        This corresponds to a code value of 58% in PQ
+        and 75% in HLG on a 1000 cd/m<sup>2</sup> display.
+        This value is assumed in various workflows
+        such as compositing or HDR to SDR content conversion.
+      </p>
+
+      <p class="note">This is the same definition,
+        and the same standard value,
+        as is used in [[ISO_22028-5]].
+      </p>
+
+      <p>Previously, it was not possible to indicate
+        that the content was mastered to some other reference level,
+        such as 100 cd/m<sup>2</sup>.
+      </p>
+
+      <p>The <span class="chunk">hRWl</span> chunk
+      indicates that HDR Reference White uses non-standard luminance level.</p>
+
+      <p>The value is encoded as a <a>PNG four-byte unsigned integer</a>.</p>
+
+      <p>The following specifies the syntax of the <span class="chunk">hRWl</span> chunk:</p>
+
+           <table id="hRWl-chunk-syntax" class="numbered simple">
+             <caption>hRWl chunk components</caption>
+
+             <tr>
+               <th>Name</th>
+               <th>Size</th>
+               <th>Divisor value</th>
+             </tr>
+
+             <tr>
+               <td>HDR Reference White level</td>
+               <td>4 bytes</td>
+               <td>0.0001 cd/m<sup>2</sup></td>
+             </tr>
+           </table>
+
+           <aside class="example">
+             Example <span class="chunk">hRWl</span> chunk HDR Reference White Level:
+
+             <table id="hRWl-chunk-white-level-example" class="numbered simple">
+               <tr>
+                 <th>Actual value</th>
+                 <th>Stored Decimal value</th>
+                 <th>Stored Hexadecimal value</th>
+               </tr>
+
+               <tr>
+                 <td>160 cd/m<sup>2</sup></td>
+                 <td>1600000</td>
+                 <td>00 18 6A 00</td>
+              </tr>
+            </table>
+          </aside>
+
+          <p>If the standard value of 203 cd/m<sup>2</sup>
+          has been used,
+          the <span class="chunk">hRWl</span> chunk
+          should <strong>not</strong> be added. 
+          The default, standard value will be assumed
+          if the chunk is absent.
+        </p>
+
+    </section>
 
 
 <!-- Maintain a fragment named "11textinfo" to preserve incoming links to it -->


### PR DESCRIPTION
As noted in 

 - #390 

this references the definition in the  (freely available) ITU-R BT.2409-9 specification, which becomes a normative reference, while noting that this is technically aligned with ISO 22028-5 (which costs 135CHF).

This should satisfy W3C criteria regarding normatively referencing specifications which are not freely available.

Both references are added to the bibliography, in their most recent (2026) editions.

For consistency, the luminance level is stored in exactly the same way as in the `cLLI` chunk (four bytes, value is multiplied by 10,000).

I also added the chunk to the [chunk ordering table](https://www.w3.org/TR/png-3/#5ChunkOrdering) but will leave adding it to the six SVG diagrams to another pull request, once this is merged.

Because the chunk is optional and contains only one value, I did not add language (like we have in `cLLi`) that a zero value means undefined. Just don't add the chunk, in that case.

I added an encoding example, similar to the ones for `cLLI`, for 160 nits.

**Note:** I am aware of the [earlier pull request for an earlier version of this chunk](https://github.com/w3c/png/pull/391) but there were many unresolved requests for changes and the references were also from 2023 so it was easier to start from scratch.

