### PR TITLE
Update SMPTE spec urls to public ones

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,23 +254,23 @@
           href: "http://www.libpng.org/pub/png/pngbook.html",
           date: "1999-06-11"
         },
-        "SMPTE-170M": {
+        "SMPTE-ST-170M": {
           title: "Television — Composite Analog Video Signal — NTSC for Studio Applications",
           publisher: "Society of Motion Picture and Television Engineers",
           date: "2004-11-30",
-          href: "https://standards.globalspec.com/std/892300/SMPTE%20ST%20170M"
+          href: "https://pub.smpte.org/doc/st170/20041130-pub/"
         },
         "SMPTE-RP-177": {
           title: "Derivation of Basic Television Color Equations",
           publisher: "Society of Motion Picture and Television Engineers",
           date: "1 November 1993",
-          href: "https://standards.globalspec.com/std/1284890/smpte-rp-177"
+          href: "https://pub.smpte.org/doc/rp177/19931101-pub/"
         },
         "SMPTE-ST 2065-1": {
           title: "Academy Color Encoding Specification (ACES)",
           publisher: "Society of Motion Picture and Television Engineers",
           date: "9 September 2020",
-          href: "https://pub.smpte.org/latest/st2065-1/"
+          href: "https://pub.smpte.org/doc/st2065-1/20200909-pub/"
         },
         "SMPTE-ST-2067-21": {
           title: "Interoperable Master Format — Application #2E",
@@ -282,13 +282,13 @@
           title: "Full-Range Image Mapping",
           publisher: "Society of Motion Picture and Television Engineers",
           date: "2013-01-01",
-          href: "https://doi.org/10.5594/SMPTE.RP2077.2013"
+          href: "https://pub.smpte.org/doc/rp2077/20131107-pub/"
         },
         "SMPTE-ST-2086": {
           title: "Mastering Display Color Volume Metadata Supporting High Luminance and Wide Color Gamut Images",
           publisher: "Society of Motion Picture and Television Engineers",
           date: "27 April 2018",
-          href: "https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8353899"
+          href: "https://pub.smpte.org/doc/st2086/20180409-pub/"
         },
         "TIFF-6.0": {
           href: "https://www.loc.gov/preservation/digital/formats/fdd/fdd000022.shtml",
@@ -5630,7 +5630,7 @@ gamma = 1/display_exponent
       "#11gAMA">gAMA</a> chunk is missing.</p>
 
       <p>There are a number of recommendations and standards for primaries and <a>white points</a>, some of which are linked to
-      particular technologies, for example the CCIR 709 standard [[ITU-R-BT.709]] and the SMPTE-C standard [[SMPTE-170M]].</p>
+      particular technologies, for example the CCIR 709 standard [[ITU-R-BT.709]] and the SMPTE-C standard [[SMPTE-ST-170M]].</p>
 
       <p>There are three cases that need to be considered:</p>
 
@@ -5700,7 +5700,7 @@ cHRM</a> chunk.</p>-->
         </tr>
       </table>
 
-      <p>An older but still very popular video standard is SMPTE-C [[SMPTE-170M]] given in <a href="#12-table122"></a>.</p>
+      <p>An older but still very popular video standard is SMPTE-C [[SMPTE-ST-170M]] given in <a href="#12-table122"></a>.</p>
       <!-- Maintain a fragment named "12-table122" to preserve incoming links to it -->
 
       <table id="12-table122" class="numbered simple">


### PR DESCRIPTION
- Checked dates for all SMPTE specs
- Changes urls to the new `pub.smpte.org/doc` ones

Except for

 - https://github.com/w3c/png/issues/576