### PR TITLE
Fix rare incorrect chunk ID spellings (`iTXT`, `tEXT`, `zTXT`, `gIFT`, `eXIF`)

### DIFF
--- a/extensions/Overview.bs
+++ b/extensions/Overview.bs
@@ -1163,7 +1163,7 @@ What are <code>x0</code> and <code>x1</code> for?
     <ul>
 
     <li>Added <code>pCAL</code> chunk and related sample code
-    </li><li>Deprecated the <code>gIFT</code> chunk
+    </li><li>Deprecated the <code>gIFt</code> chunk
     </li><li>Added sample gamma-correction code that uses integer arithmetic
 
     </li></ul>

--- a/extensions/Overview.bs
+++ b/extensions/Overview.bs
@@ -1098,7 +1098,7 @@ What are <code>x0</code> and <code>x1</code> for?
     <li>24 Jan Dec 2022 (version 1.6.0)</li>
 
     <ul>
-        <li>Moved <span class="chunk">eXIF</span> to main PNG document</li>
+        <li>Moved <span class="chunk">eXIf</span> to main PNG document</li>
         <li>Converted source document to Bikeshed</li>
     </ul>
 

--- a/index.html
+++ b/index.html
@@ -7298,7 +7298,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
           types cannot be evaluated, particularly unregistered chunks. However, it is the intention of the PNG Working Group to
           disallow chunks containing "executable" data to become registered chunks.</p>
 
-          <p>The text chunks, <a class="chunk" href="#11tEXt">tEXt</a>, <a class="chunk" href="#11iTXt">iTXT</a> and <a class=
+          <p>The text chunks, <a class="chunk" href="#11tEXt">tEXt</a>, <a class="chunk" href="#11iTXt">iTXt</a> and <a class=
           "chunk" href="#11zTXt">zTXt</a>, contain data that can be displayed in the form of comments, etc. Some operating systems
           or terminals might allow the display of textual data with embedded control characters to perform operations such as
           re-mapping of keys, creation of files, etc. For this reason, the specification recommends that the text chunks be

--- a/tools.md
+++ b/tools.md
@@ -41,7 +41,7 @@ Command-line tool in C++ to insert (and optionally, overwrite) a `cICP` chunk in
 
 [Homepage](https://github.com/finnp/png-itxt/blob/master/readme.md) and [maintained on GitHub](https://github.com/finnp/png-itxt).
 
-Tool to read textual information in `tEXt`, `zTXT` and `iTXt` chunks, and to write `iTXt` chunks. Use in Node programs, or on command line.
+Tool to read textual information in `tEXt`, `zTXt` and `iTXt` chunks, and to write `iTXt` chunks. Use in Node programs, or on command line.
 
 ### Animated PNG Maker
 
@@ -111,7 +111,7 @@ Multi-platform GUI which displays metadata on many image and video formats inclu
 
 [Homepage](https://www.dcode.fr/png-chunks).
 
-Online tool to extract contents of `tEXt`, `zTXT` and `iTXt` chunks.
+Online tool to extract contents of `tEXt`, `zTXt` and `iTXt` chunks.
 
 ## Libraries
 

--- a/tools.md
+++ b/tools.md
@@ -41,7 +41,7 @@ Command-line tool in C++ to insert (and optionally, overwrite) a `cICP` chunk in
 
 [Homepage](https://github.com/finnp/png-itxt/blob/master/readme.md) and [maintained on GitHub](https://github.com/finnp/png-itxt).
 
-Tool to read textual information in `tEXT`, `zTXT` and `iTXt` chunks, and to write `iTXt` chunks. Use in Node programs, or on command line.
+Tool to read textual information in `tEXt`, `zTXT` and `iTXt` chunks, and to write `iTXt` chunks. Use in Node programs, or on command line.
 
 ### Animated PNG Maker
 
@@ -111,7 +111,7 @@ Multi-platform GUI which displays metadata on many image and video formats inclu
 
 [Homepage](https://www.dcode.fr/png-chunks).
 
-Online tool to extract contents of `tEXT`, `zTXT` and `iTXt` chunks.
+Online tool to extract contents of `tEXt`, `zTXT` and `iTXt` chunks.
 
 ## Libraries
 

--- a/tools.md
+++ b/tools.md
@@ -41,7 +41,7 @@ Command-line tool in C++ to insert (and optionally, overwrite) a `cICP` chunk in
 
 [Homepage](https://github.com/finnp/png-itxt/blob/master/readme.md) and [maintained on GitHub](https://github.com/finnp/png-itxt).
 
-Tool to read textual information in `tEXT`, `zTXT` and `iTXT` chunks, and to write `iTXT` chunks. Use in Node programs, or on command line.
+Tool to read textual information in `tEXT`, `zTXT` and `iTXt` chunks, and to write `iTXt` chunks. Use in Node programs, or on command line.
 
 ### Animated PNG Maker
 
@@ -111,7 +111,7 @@ Multi-platform GUI which displays metadata on many image and video formats inclu
 
 [Homepage](https://www.dcode.fr/png-chunks).
 
-Online tool to extract contents of `tEXT`, `zTXT` and `iTXT` chunks.
+Online tool to extract contents of `tEXT`, `zTXT` and `iTXt` chunks.
 
 ## Libraries
 


### PR DESCRIPTION
I found these errors in chunk ID casing using [ripgrep](https://github.com/BurntSushi/ripgrep) as follows (the output corresponds to https://github.com/w3c/png/commit/426e411b13ae3853984f14c9269766adec8d6d15, i.e. the latest commit on [`main`](https://github.com/w3c/png/tree/main) as of this writing):

```console
$ rg --version
ripgrep 15.2.0 (rev e89fff89ac)

features:+pcre2
simd(compile):+SSE2,-SSSE3,-AVX2
simd(runtime):+SSE2,+SSSE3,+AVX2

PCRE2 10.45 is available (JIT is available)

$ rg --no-filename -o -w '[A-Za-z]{2}[A-Z][A-Za-z]' | sort -u | uniq -i -D
cICP
CICP
cLLi
cLLI
eXIf
eXIF
EXIF
fdAT
fDAT
gIFt
gIFT
iTXt
iTXT
sRGB
SRGB
tEXt
tEXT
zTXt
zTXT
```

I searched for each of these throughout the entire repository, and for most of them, I concluded that they were fine and shouldn't be changed. I corrected only the remaining ones.

Note that b5e58c752fc43397d9b0c029ecbadb07883a2ee4 and cabfbfa0ecc4bf4ec2621d95cabf63de2ee08ec0 modify the source file `extensions/Overview.bs`, but I deliberately didn't update `extensions/Overview.html`, because I realized that you would probably want to regenerate it rather than modifying it directly.

I don't know how to regenerate `extensions/Overview.html`, and it would probably be much easier for you to do it the way you want.